### PR TITLE
Standardize runtime and log folders for UCI

### DIFF
--- a/wrapper/hosts.py
+++ b/wrapper/hosts.py
@@ -77,9 +77,6 @@ class BaseHost(object):
     def create_runner(self, *args, **kwargs):
         raise NotImplementedError()
 
-    def get_logs(self):
-        return ('/tmp', '/tmp')
-
     def get_tag(self):
         return self._tag
 
@@ -125,11 +122,6 @@ class CNVHost(BaseHost):
 
     def create_runner(self, *args, **kwargs):
         return SubprocessRunner(self, *args, **kwargs)
-
-    def get_logs(self):
-        # TODO: we should either pipe everything to stdout or push to log
-        # collector
-        return ('/tmp', '/tmp')
 
     def handle_finish(self, data):
         """ Handle finish after successfull conversion """
@@ -276,12 +268,6 @@ class OSPHost(BaseHost):
             return SystemdRunner(self, *args, **kwargs)
         else:
             return SubprocessRunner(self, *args, **kwargs)
-
-    def get_logs(self):
-        log_dir = '/var/log/virt-v2v'
-        if not os.path.isdir(log_dir):
-            os.makedirs(log_dir)
-        return (log_dir, log_dir)
 
     def handle_cleanup(self, data):
         """ Handle cleanup after failed conversion """
@@ -608,7 +594,6 @@ class VDSMHost(BaseHost):
         (1, br'virtio-win-([0-9.]+).iso'),
         (0, br'virtio-win\.iso'),
         ]
-    VDSM_LOG_DIR = '/var/log/vdsm/import'
     VDSM_MOUNTS = '/rhev/data-center/mnt'
     VDSM_CA = '/etc/pki/vdsm/certs/cacert.pem'
     VDSM_UID = 36  # vdsm
@@ -656,10 +641,6 @@ class VDSMHost(BaseHost):
             return SystemdRunner(self, *args, **kwargs)
         else:
             return SubprocessRunner(self, *args, **kwargs)
-
-    def get_logs(self):
-        """ Returns tuple with directory for virt-v2v log and wrapper log """
-        return (self.VDSM_LOG_DIR, self.VDSM_LOG_DIR)
 
     def handle_cleanup(self, data):
         with self.sdk_connection(data) as conn:

--- a/wrapper/tests/test_v2v_args.py
+++ b/wrapper/tests/test_v2v_args.py
@@ -72,21 +72,21 @@ class TestV2vArgs(unittest.TestCase):
         data['luks_keys_files'] = [
             {
                 'device': '/dev/sda1',
-                'filename': '/tmp/luks/sda1',
+                'filename': '/var/tmp/luks/sda1',
             },
             {
                 'device': '/dev/sda2',
-                'filename': '/tmp/luks/sda2',
+                'filename': '/var/tmp/luks/sda2',
             },
         ]
         v2v_args, v2v_env = wrapper.prepare_command(data, [])
         self.assert_has_args(
             v2v_args,
-            ['--key', '/dev/sda1:file:/tmp/luks/sda1'],
+            ['--key', '/dev/sda1:file:/var/tmp/luks/sda1'],
             'Looking for LUKS key of device sda1 %r' % v2v_args)
         self.assert_has_args(
             v2v_args,
-            ['--key', '/dev/sda2:file:/tmp/luks/sda2'],
+            ['--key', '/dev/sda2:file:/var/tmp/luks/sda2'],
             'Looking for LUKS key of device sda2 %r' % v2v_args)
 
     def test_network_mappings(self):

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -44,8 +44,9 @@ DEVNULL = getattr(subprocess, 'DEVNULL', open(os.devnull, 'r+'))
 # Wrapper version
 VERSION = "23"
 
+RUN_DIR = '/var/lib/uci'
+LOG_DIR = '/var/log/uci'
 LOG_LEVEL = logging.DEBUG
-STATE_DIR = '/tmp'
 
 
 ############################################################################
@@ -388,17 +389,12 @@ def main():
 
     # The logging is delayed until we now which user runs the wrapper.
     # Otherwise we would have two logs.
-    log_tag = host.get_tag()
-    log_dirs = host.get_logs()
-    STATE.v2v_log = os.path.join(log_dirs[0], 'v2v-import-%s.log' % log_tag)
-    STATE.machine_readable_log = os.path.join(
-        log_dirs[0], 'v2v-import-%s-mr.log' % log_tag)
-    wrapper_log = os.path.join(log_dirs[1],
-                               'v2v-import-%s-wrapper.log' % log_tag)
-    STATE.state_file = os.path.join(STATE_DIR, 'v2v-import-%s.state' % log_tag)
-    throttling_file = os.path.join(STATE_DIR,
-                                   'v2v-import-%s.throttle' % log_tag)
-    STATE.internal['throttling_file'] = throttling_file
+    STATE.v2v_log = os.path.join(LOG_DIR, 'virt-v2v.log')
+    STATE.machine_readable_log = os.path.join(LOG_DIR, 'virt-v2v-mr.log')
+    wrapper_log = os.path.join(LOG_DIR, 'virt-v2v-wrapper.log')
+    STATE.state_file = os.path.join(RUN_DIR, 'state.json')
+    throttling_file = os.path.join(RUN_DIR, 'limits.json')
+    STATE['internal']['throttling_file'] = throttling_file
 
     log_format = '%(asctime)s:%(levelname)s:' \
         + ' %(message)s (%(module)s:%(lineno)d)'

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -393,8 +393,7 @@ def main():
     STATE.machine_readable_log = os.path.join(LOG_DIR, 'virt-v2v-mr.log')
     wrapper_log = os.path.join(LOG_DIR, 'virt-v2v-wrapper.log')
     STATE.state_file = os.path.join(RUN_DIR, 'state.json')
-    throttling_file = os.path.join(RUN_DIR, 'limits.json')
-    STATE['internal']['throttling_file'] = throttling_file
+    STATE.internal.throttling_file = os.path.join(RUN_DIR, 'limits.json')
 
     log_format = '%(asctime)s:%(levelname)s:' \
         + ' %(message)s (%(module)s:%(lineno)d)'
@@ -407,7 +406,8 @@ def main():
 
     logging.info('Will store virt-v2v log in: %s', STATE.v2v_log)
     logging.info('Will store state file in: %s', STATE.state_file)
-    logging.info('Will read throttling limits from: %s', throttling_file)
+    logging.info('Will read throttling limits from: %s',
+                 STATE.internal['throttling_file'])
 
     password_files = []
 
@@ -529,7 +529,7 @@ def main():
                 'v2v_log': STATE.v2v_log,
                 'wrapper_log': wrapper_log,
                 'state_file': STATE.state_file,
-                'throttling_file': throttling_file,
+                'throttling_file': STATE.internal['throttling_file'],
             }))
 
             # Let's get to work


### PR DESCRIPTION
When moving to a container only approach, we mount conversion host folders in the container at runtime to store state and limits, as well as logs outside of the container. In the existing implementation, the folders for logs are different depending on the destination provider:

- `/var/log/vdsm/import` for RHV
- `/var/log/virt-v2v` for OpenStack
- `/tmp` for CNV

This pull request standardize them the `/var/log/uci`. From a conversion host point of view, ManageIQ creates `/var/log/uci/<task_id>` folder and mounts it to `/var/log/uci` in the container to isolate each migration task: https://github.com/ManageIQ/manageiq/pull/19698.

With this change, there no need to apply a tag to the file names to differentiate them. This pull request removes the tag from the file names and makes them consistent with what ManageIQ code.

For the files used to interact with ManageIQ, i.e. state and limits files, instead of putting them in `/tmp`, this pull request relocates them in `/var/lib/uci`. Similarly to log folder, it will match `/var/lib/uci/<task_id>` folder created by ManageIQ on the conversion host. This reduces the number of mounts in the container to `/dev`, `/var/tmp`, `/var/lib/uci/<task_id>, `/var/log/uci/<task_id>` and `/opt/vmware-vix-disklib-distrib`.

For the LUKS keys, the existing default path doesn't make sense within a container. The pull request updates it to `/var/lib/uci/luks_keys/vault.json`. The folder will also be mounted in the container.

~~Because `/tmp` will not be mounted, the pull request also modifies the tests for LUKS keys files to be in `/var/tmp` for consistency.~~