### PR TITLE
Remove Python 2 specific code and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: python
 python:
-  - "2.7"
   - "3.6"
   - "3.7"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist = yamllint,flake8,py{27,36,37}-wrapper,pylint
+envlist = yamllint,flake8,py{36,37}-wrapper,pylint
 skip_missing_interpreters=True
 
 [flake8]
@@ -10,16 +10,12 @@ exclude = .git,.eggs,.tox,__pycache__,venv,build,dist
 usedevelop = True
 deps =
     -r{toxinidir}/requirements.txt
-    py27: mock
 
 [testenv:yamllint]
 commands = yamllint -c {toxinidir}/.yamllint {toxinidir}/
 
 [testenv:flake8]
 commands = flake8 --statistics {posargs} .
-
-[testenv:py27-wrapper]
-commands = {toxinidir}/wrapper/tests/run_tests.sh
 
 [testenv:py36-wrapper]
 commands = {toxinidir}/wrapper/tests/run_tests.sh

--- a/v2v-conversion-host.spec.in
+++ b/v2v-conversion-host.spec.in
@@ -1,18 +1,6 @@
-%if 0%{?fedora} || 0%{?rhel} > 7
-%bcond_without python3
-%else
-%bcond_with python3
-%endif
-
-%if %{with python3}
 %global python %{__python3}
 BuildRequires: %{py3_dist setuptools}
 BuildRequires: python3-devel
-%else
-%global python %{__python}
-BuildRequires: python-setuptools
-BuildRequires: python-devel
-%endif
 
 %global rolename v2v-conversion-host
 %global roleprefix oVirt.
@@ -48,14 +36,8 @@ Ansible role to setup hosts as conversion host for ManageIQ
 Summary: Daemonizing wrapper for virt-v2v
 BuildArch: noarch
 Requires: libcgroup-tools
-%if %{with python3}
 Requires: python3
 Requires: %{py3_dist pycurl}
-%else
-Requires: python >= 2.7
-Requires: python-pycurl
-Requires: python-six
-%endif
 
 %description wrapper
 Daemonizing wrapper for virt-v2v.

--- a/wrapper/hosts.py
+++ b/wrapper/hosts.py
@@ -11,8 +11,6 @@ import uuid
 
 from contextlib import contextmanager
 from io import BytesIO
-# TODO: [py2] Remove the comment for newer pylint
-# pylint: disable=bad-option-value,relative-import
 from six.moves.urllib.parse import urlparse
 
 from .common import error, hard_error, log_command_safe

--- a/wrapper/log_parser.py
+++ b/wrapper/log_parser.py
@@ -1,18 +1,12 @@
 import json
 import os
 import re
-import six
 import time
 import logging
 from contextlib import contextmanager
 
 from .state import STATE, Disk
 from .common import error
-
-if six.PY2:
-    py2unimode = 'U'
-else:
-    py2unimode = ''
 
 
 class OutputParser(object):
@@ -48,8 +42,8 @@ class OutputParser(object):
                     and os.path.exists(STATE.machine_readable_log):
                 continue
             time.sleep(1)
-        self._log = open(STATE.v2v_log, 'rb' + py2unimode)
-        self._machine_log = open(STATE.machine_readable_log, 'rb' + py2unimode)
+        self._log = open(STATE.v2v_log, 'rb')
+        self._machine_log = open(STATE.machine_readable_log, 'rb')
         self._current_disk = None
         self._current_path = None
         self._duplicate = duplicate
@@ -66,8 +60,7 @@ class OutputParser(object):
                 if message.get('type') == 'error':
                     message = message.get('message')
                     error('virt-v2v error: {}'.format(message))
-            # TODO: [py2] Just use JSONDecodeError
-            except getattr(json.decoder, 'JSONDecodeError', ValueError):
+            except json.decoder.JSONDecodeError:
                 logging.exception(
                     'Failed to parse line from'
                     ' virt-v2v machine readable output')

--- a/wrapper/runners.py
+++ b/wrapper/runners.py
@@ -1,10 +1,6 @@
-import os
 import subprocess
 
 VIRT_V2V = '/usr/bin/virt-v2v'
-
-# TODO: [py2] Remove the line and use DEVNULL from subprocess directly
-DEVNULL = getattr(subprocess, 'DEVNULL', open(os.devnull, 'r+'))
 
 
 class BaseRunner(object):
@@ -61,7 +57,7 @@ class SubprocessRunner(BaseRunner):
         with open(self._log, 'w') as log:
             self._proc = subprocess.Popen(
                     [VIRT_V2V] + self._arguments,
-                    stdin=DEVNULL,
+                    stdin=subprocess.DEVNULL,
                     stderr=subprocess.STDOUT,
                     stdout=log,
                     env=self._environment,

--- a/wrapper/tests/test_routines.py
+++ b/wrapper/tests/test_routines.py
@@ -1,11 +1,6 @@
 import logging
 import unittest
-try:
-    # Python 2
-    from cStringIO import StringIO
-except ImportError:
-    # Python 3
-    from io import StringIO
+from io import StringIO
 
 from wrapper import virt_v2v_wrapper as wrapper
 

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -34,9 +34,6 @@ from .hosts import BaseHost, CNVHost
 from .log_parser import log_parser
 from .checks import CHECKS
 
-# py2
-DEVNULL = getattr(subprocess, 'DEVNULL', open(os.devnull, 'r+'))
-
 # Wrapper version
 VERSION = "23"
 
@@ -171,7 +168,7 @@ def spawn_ssh_agent(data, uid, gid):
         out = subprocess.check_output(
             cmd,
             stderr=subprocess.STDOUT,
-            stdin=DEVNULL)
+            stdin=subprocess.DEVNULL)
     except subprocess.CalledProcessError as e:
         error('Failed to start ssh-agent', exception=True)
         logging.error('Command failed with: %s', e.output)
@@ -207,7 +204,7 @@ def spawn_ssh_agent(data, uid, gid):
             cmd,
             env=env,
             stderr=subprocess.STDOUT,
-            stdin=DEVNULL)
+            stdin=subprocess.DEVNULL)
     except subprocess.CalledProcessError as e:
         error('Failed to add SSH keys to the agent', exception=True)
         logging.error("ssh-add output: %s", e.output)


### PR DESCRIPTION
When moving to a container only approach, the container image is built from `rhel8` or `centos8` image. In these images, Python 3 is the default version. And Python 2 is officially deprecated in the language itself. This pull request removes code and tests specific to Python 2.

Note: `wrapper/tc.py` file is left untouched as it will be altered in another pull request.