### PR TITLE
Remove code related to RHV host

### DIFF
--- a/docs/Virt-v2v-wrapper.md
+++ b/docs/Virt-v2v-wrapper.md
@@ -139,10 +139,6 @@ with `rhv_url` some other keys need to be also specified.
 
 * `rhv_storage`: name of the target storage domain
 
-* `rhv_cafile`: optional on VDSM host; path to the CA certificate. If the key
-  is not specified wrapper looks for the certificate at the default VDSM
-  location.
-
 * `insecure_connection`: optional, whether to verify peer certificates. For now
   used only when connecting to oVirt/RHV. Default is `false`.
 
@@ -154,7 +150,6 @@ Example:
         "rhv_password": "secret-password",
         "rhv_cluster": "Default",
         "rhv_storage": "data",
-        "rhv_cafile": "/etc/pki/vdsm/certs/cacert.pem",
         "insecure_connection": true
     }
 

--- a/docs/Virt-v2v-wrapper.md
+++ b/docs/Virt-v2v-wrapper.md
@@ -67,18 +67,8 @@ Miscellaneous:
    specified, it is used to connect the VM's NICs to the destination networks
    during the conversion using virt-v2v `--bridge` option.
 
-* `virtio_win`: optional key containing path to virtio-win ISO image; this is
-  useful for installing Windows drivers to the VM during conversion. It may be
-  either absolute path or only a filename in which case path to ISO domain is
-  auto-detected.
-
 * `install_drivers`: optional key whether to install Windows drivers during
-  conversion, default is `false`. If `install_drivers` is `true` and
-  `virtio_win` is not specified, wrapper attempts to automatically select best
-  ISO from the ISO domain. Note that when no ISO is found this does not lead to
-  failed conversion. Just no drivers will be installed in this case. This is
-  different from situation when `virtio_win` is specified but points to
-  non-existing ISO, which is an error.
+  conversion, default is `false`.
 
 * `allocation`: optional key specifying the allocation type to use; possible
   values are `preallocated` and `sparse`.
@@ -86,45 +76,11 @@ Miscellaneous:
 * `luks_keys_vault`: optional key to specify a JSON file containing the LUKS
   keys for encrypted devices (see below).
 
-Example:
-
-    {
-        "export_domain": "storage1.example.com:/data/export-domain",
-        "vm_name": "My_Machine",
-
-        "transport_method": "vddk",
-        "vmware_fingerprint": "1A:3F:26:C6:DC:2C:44:88:AA:33:81:3C:18:6E:5D:9F:C0:EE:DF:5C",
-        "vmware_uri": "esx://root@10.2.0.20?no_verify=1",
-        "vmware_password": "secret-password",
-
-        "source_disks": [
-            "[dataStore_1] My_Machine/My_Machine_1.vmdk",
-            "[dataStore_1] My_Machine/My_Machine_2.vmdk"
-        ],
-        "network_mappings": [
-            {
-                "source": "networkA1",
-                "destination": "networkA2"
-            },
-            {
-                "source": "networkX1",
-                "destination": "networkX2"
-            }
-        ],
-        "virtio_win": "virtio-win-0.1.141.iso",
-        "luks_keys_vault": "/path_to/luks_key_vault.json"
-    }
-
 ## Output configuration
 
 There is no configuration key specifying the type of output. Rather the output
-method is chosen depending on the keys present. If there are keys defining
-multiple output modes the first one is selected base on the order of
-precedence. The order is following:
-
-1)  oVirt API upload
-
-2)  export domain
+method is chosen depending on the keys present. The only supported output mode
+is oVirt API upload.
 
 ### oVirt API upload
 
@@ -140,27 +96,42 @@ with `rhv_url` some other keys need to be also specified.
 * `rhv_storage`: name of the target storage domain
 
 * `insecure_connection`: optional, whether to verify peer certificates. For now
-  used only when connecting to oVirt/RHV. Default is `false`.
+  used only when connecting to oVirt/RHV. Default is `false`. The default path
+  for the CA certificates file is
+  `/etc/pki/ca-trust/source/anchors/v2v-conversion-host-ca-bundle.pem`.
 
 Example:
 
     {
-        ...
+        "vm_name": "My_Machine",
+
+        "transport_method": "vddk",
+        "vmware_fingerprint": "1A:3F:26:C6:DC:2C:44:88:AA:33:81:3C:18:6E:5D:9F:C0:EE:DF:5C",
+        "vmware_uri": "esx://root@10.2.0.20?no_verify=1",
+        "vmware_password": "secret-password",
+
         "rhv_url": "https://ovirt.example.com/ovirt-engine/api",
         "rhv_password": "secret-password",
         "rhv_cluster": "Default",
         "rhv_storage": "data",
         "insecure_connection": true
+
+        "source_disks": [
+            "[dataStore_1] My_Machine/My_Machine_1.vmdk",
+            "[dataStore_1] My_Machine/My_Machine_2.vmdk"
+        ],
+        "network_mappings": [
+            {
+                "source": "networkA1",
+                "destination": "networkA2"
+            },
+            {
+                "source": "networkX1",
+                "destination": "networkX2"
+            }
+        ],
+        "luks_keys_vault": "/path_to/luks_key_vault.json"
     }
-
-
-### Export domain
-
-To request conversion into export domain add the following key to the
-configuration:
-
-* `export_domain`: specify path to NFS share in the format `<hostname>:<path>`
-
 
 ## State File Format
 

--- a/wrapper/checks.py
+++ b/wrapper/checks.py
@@ -1,8 +1,8 @@
-VDSM_MIN_RHV = '4.2.4'  # This has to match VDSM_MIN_VERSION!
+VDSM_MIN_OVIRT = '4.2.4'  # This has to match VDSK_MIN_VERSION!
 VDSM_MIN_VERSION = '4.20.31'  # RC4, final
 
 
-def check_rhv_version():
+def check_ovirt_version():
     try:
         import rpmUtils.transaction
         import rpmUtils.miscutils
@@ -23,10 +23,10 @@ def check_rhv_version():
         print('Version of VDSM on the host: {}{}'.format(
                 '' if vdsm['epoch'] is None else '%s:' % vdsm['epoch'],
                 vdsm['version']))
-    print('Minimal required oVirt/RHV version is %s' % VDSM_MIN_RHV)
+    print('Minimal required oVirt/RHV version is %s' % VDSM_MIN_OVIRT)
     return False
 
 
 CHECKS = {
-    'rhv-version': check_rhv_version,
+    'ovirt-version': check_ovirt_version,
 }

--- a/wrapper/tests/test_ovirt.py
+++ b/wrapper/tests/test_ovirt.py
@@ -13,7 +13,6 @@ class TestOvirt(unittest.TestCase):
         'rhv_password_file': '/rhv/password',
         'rhv_cluster': 'Default',
         'rhv_storage': 'data',
-        'rhv_cafile': '/rhv/ca.pem',
 
         'vmware_fingerprint': '01:23:45:67:89:AB:CD:EA:DB:EE:F0:12:34:56:78:9A:BC:DE:F0:12',  # NOQA E501
         'vmware_uri': 'esx://root@1.2.3.4?',

--- a/wrapper/tests/test_v2v_args.py
+++ b/wrapper/tests/test_v2v_args.py
@@ -38,7 +38,6 @@ class TestV2vArgs(unittest.TestCase):
         'rhv_password_file': '/rhv/password',
         'rhv_cluster': 'Default',
         'rhv_storage': 'data',
-        'rhv_cafile': '/rhv/ca.pem',
 
         'vmware_fingerprint': '01:23:45:67:89:AB:CD:EA:DB:EE:F0:12:34:56:78:9A:BC:DE:F0:12',  # NOQA E501
         'vmware_uri': 'esx://root@1.2.3.4?',

--- a/wrapper/tests/testrunner.py
+++ b/wrapper/tests/testrunner.py
@@ -3,7 +3,7 @@ import unittest
 
 from test_osp import *  # NOQA
 from test_output_parser import *  # NOQA
-from test_rhv import *  # NOQA
+from test_ovirt import *  # NOQA
 from test_routines import *  # NOQA
 from test_state import *  # NOQA
 from test_v2v_args import *  # NOQA

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -93,10 +93,8 @@ def prepare_command(data, v2v_caps, agent_sock=None):
     # Prepare environment
     v2v_env = os.environ.copy()
     v2v_env['LANG'] = 'C'
-    if 'backend' in data:
-        if data['backend'] == 'direct':
-            logging.debug('Using direct backend. Hack, hack...')
-        v2v_env['LIBGUESTFS_BACKEND'] = data['backend']
+    logging.debug('Using direct backend. Hack, hack...')
+    v2v_env['LIBGUESTFS_BACKEND'] = 'direct'
     if agent_sock is not None:
         v2v_env['SSH_AUTH_SOCK'] = agent_sock
 


### PR DESCRIPTION
When moving to a container only approach, `virt-v2v-wrapper` will not have access to the oVirt host resources and will run as `root`. This means that we can cleanup the code. This pull request does the following things:

- Rename RHV to oVirt wherever possible (`virt-v2v` uses `rhv` in its options names)
- Remove code related to export domain as we only use `rhv_upload` mechanism
- Enforce `direct` backend for all providers
- Remove `VDSM` related constants and variables in `OvirtHost` class
- Remove CA certificate path for `ovirtsdk4` code

Note: we still need CA certificate path for `virt-v2v`, because it's a mandatory option [[BZ#1791240](https://bugzilla.redhat.com/show_bug.cgi?id=1791240)]. The path is fixed, so we make it a constant. 