### PR TITLE
Rename downstream to upstream

### DIFF
--- a/wrapper/tests/test_openstack.py
+++ b/wrapper/tests/test_openstack.py
@@ -2,11 +2,11 @@ import unittest
 from wrapper import hosts
 
 
-class TestOSP(unittest.TestCase):
+class TestOpenstack(unittest.TestCase):
     """ Tests specific to OpenStack """
 
     def test_disk_naming(self):
-        host = hosts.OSPHost()
+        host = hosts.OpenstackHost()
         with self.assertRaises(ValueError):
             host._get_disk_name(0)
         self.assertEqual('vda', host._get_disk_name(1))
@@ -20,7 +20,7 @@ class TestOSP(unittest.TestCase):
         self.assertEqual('vdzz', host._get_disk_name(702))
 
     def test_ip_conversions(self):
-        host = hosts.OSPHost()
+        host = hosts.OpenstackHost()
         self.assertEqual(
             '11000000101010000000000000101010',
             host._ip_to_binary('192.168.0.42')

--- a/wrapper/tests/test_output_parser.py
+++ b/wrapper/tests/test_output_parser.py
@@ -81,7 +81,7 @@ class TestOutputParser(unittest.TestCase):
                 STATE.internal['disk_ids'][path],
                 b'11111111-1111-1111-1111-111111111111')
 
-    def test_osp_volume_uuid(self):
+    def test_openstack_volume_uuid(self):
         STATE.v2v_log = '/dev/null'
         STATE.machine_readable_log = '/dev/null'
         with wrapper.log_parser() as parser:

--- a/wrapper/tests/testrunner.py
+++ b/wrapper/tests/testrunner.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import unittest
 
-from test_osp import *  # NOQA
+from test_openstack import *  # NOQA
 from test_output_parser import *  # NOQA
 from test_ovirt import *  # NOQA
 from test_routines import *  # NOQA

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -30,7 +30,7 @@ import time
 
 from .state import STATE, Disk
 from .common import error, hard_error, log_command_safe
-from .hosts import BaseHost, CNVHost
+from .hosts import BaseHost, KubevirtHost
 from .log_parser import log_parser
 from .checks import CHECKS
 
@@ -123,7 +123,7 @@ def wrapper(host, data, v2v_caps, agent_sock=None):
     try:
         STATE.started = True
         STATE.write()
-        with log_parser(isinstance(host, CNVHost)) as parser:
+        with log_parser(isinstance(host, KubevirtHost)) as parser:
             while runner.is_running():
                 parser.parse()
                 STATE.write()


### PR DESCRIPTION
In the current implementation, the code uses the downstream projects names for the various classes and variables names. The manageiq-v2v-conversion_host project is an upstream project, so we should prefer upstream projects names whenever possible.

This pull request replaces `RHV` with `oVirt`, `OSP` with `Openstack` and `CNV` with `Kubevirt` whenever possible. Some occurences are still present:

- Some attributes of the input `data` are still prefixed with `rhv` or `osp`. They can be renamed jointly with the ServiceTemplateTransformationPlanTask that generates it. It will be done in separate pull requests.

- Some options of `virt-v2v` use `rhv` or `osp`. This would require changes in `libguestfs` and `virt-v2v`, so it will take more time, if it's ever implemented.


Built on https://github.com/ManageIQ/manageiq-v2v-conversion_host/pull/6