### PR TITLE
Standardize string formatting with % notation

### DIFF
--- a/wrapper/checks.py
+++ b/wrapper/checks.py
@@ -20,9 +20,10 @@ def check_ovirt_version():
             rpmUtils.miscutils.stringToVersion(VDSM_MIN_VERSION))
         if res >= 0:
             return True
-        print('Version of VDSM on the host: {}{}'.format(
-                '' if vdsm['epoch'] is None else '%s:' % vdsm['epoch'],
-                vdsm['version']))
+        if vdsm['epoch'] is None:
+            vdsm['epoch'] = ''
+        print('Version of VDSM on the host: %s%s' %
+              (vdsm['epoch'], vdsm['version']))
     print('Minimal required oVirt/RHV version is %s' % VDSM_MIN_OVIRT)
     return False
 

--- a/wrapper/hosts.py
+++ b/wrapper/hosts.py
@@ -111,7 +111,7 @@ class KubevirtHost(BaseHost):
     def handle_finish(self, data):
         """ Handle finish after successfull conversion """
         # Store JSON into annotation
-        with open('/data/vm/{}.json'.format(data['vm_name']), 'rb') as f:
+        with open('/data/vm/%s.json' % data['vm_name'], 'rb') as f:
             vm_data = f.read().decode('utf-8')
             patch = [{
                 "op": "add",
@@ -190,17 +190,12 @@ class K8SCommunicator(object):
         with open(os.path.join(account_dir, 'token')) as f:
             self._token = f.read()
 
-        self._url = (
-            'https://{host}:{port}'
-            '/api/v1/namespaces/{ns}/pods/{pod}').format(
-                host=self._host,
-                port=self._port,
-                ns=self._ns,
-                pod=self._pod)
+        self._url = ('https://%s:%s/api/v1/namespaces/%s/pods/%s' %
+                     (self._host, self._port, self._ns, self._pod))
         # too early for logging
         # logging.info('Accessing Kubernetes on: %s', self._url)
         self._headers = [
-            'Authorization: Bearer {}'.format(self._token),
+            'Authorization: Bearer %s' % self._token,
             'Accept: application/json',
         ]
 

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -169,7 +169,7 @@ def spawn_ssh_agent(data, uid, gid):
         error('Failed to start ssh-agent', exception=True)
         logging.error('Command failed with: %s', e.output)
         return None, None
-    logging.debug('ssh-agent: %s' % out)
+    logging.debug('ssh-agent: %s', out)
     sock = re.search(br'^SSH_AUTH_SOCK=([^;]+);', out, re.MULTILINE)
     pid = re.search(br'^echo Agent pid ([0-9]+);', out, re.MULTILINE)
     if not sock or not pid:
@@ -273,7 +273,7 @@ def main():
     virt_v2v_caps = virt_v2v_capabilities()
     if virt_v2v_caps is None:
         hard_error('Could not get virt-v2v capabilities.')
-    logging.debug("virt-v2v capabilities: %r" % virt_v2v_caps)
+    logging.debug("virt-v2v capabilities: %r", virt_v2v_caps)
 
     try:
 

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -52,7 +52,7 @@ def prepare_command(data, v2v_caps, agent_sock=None):
         '-v', '-x',
         data['vm_name'],
         '--root', 'first',
-        '--machine-readable=file:{}'.format(STATE.machine_readable_log),
+        '--machine-readable=file:%s' % STATE.machine_readable_log,
     ]
 
     if data['transport_method'] == 'vddk':


### PR DESCRIPTION
We quickly discussed the opportunity to standardize string formatting mechanism in wrapper. It seems that f-strings don't play well with `logging`, so we can't really standardize on f-strings. The `.format` method seems a bit old school and the `%` notation is pretty explicit. This pull request proposes standardizing with `%` notation. And this requires just a few changes.