### PR TITLE
Use input from /var/lib/uci in entrypoint

### DIFF
--- a/kubevirt-conversion/entrypoint
+++ b/kubevirt-conversion/entrypoint
@@ -36,8 +36,15 @@ if ls /dev/v2v-disk* 2>/dev/null ; then
   done
 fi
 
+if [ -f "/data/input/conversion.json" ] ; then
+  ln -s /data/input/conversion.json /var/lib/uci/input.json
+fi
+
+echo "Lising content of /var/lib/uci"
+ls -lR /var/lib/uci
+
 echo "Listing content of /data"
 ls -lR /data
 
 echo "Starting virt-v2v-wrapper..."
-exec /usr/bin/virt-v2v-wrapper $@ < /data/input/conversion.json
+exec /usr/bin/virt-v2v-wrapper $@ < /var/lib/uci/input.json

--- a/kubevirt-conversion/entrypoint
+++ b/kubevirt-conversion/entrypoint
@@ -41,10 +41,10 @@ if [ -f "/data/input/conversion.json" ] ; then
 fi
 
 echo "Lising content of /var/lib/uci"
-ls -lR /var/lib/uci
+ls -lR /var/lib/uci || true
 
 echo "Listing content of /data"
-ls -lR /data
+ls -lR /data || true
 
 echo "Starting virt-v2v-wrapper..."
 exec /usr/bin/virt-v2v-wrapper $@ < /var/lib/uci/input.json


### PR DESCRIPTION
In existing implementation, virt-v2v-wrapper reads the configuration from its standard input. For migration to Kubevirt, it was decided to store it in `/data/input/conversion.json` file. With ManageIQ, we thought that it might be interesting to have all persistent assets in `/var/lib/uci`.

In order to not break Kubevirt code, this pull request links `/data/input/conversion.json` as `var/lib/uci/input.json`. It also update the path of the input file to use `/var/lib/uci/input.json`.