### PR TITLE
Move write_password method to common

### DIFF
--- a/wrapper/common.py
+++ b/wrapper/common.py
@@ -6,6 +6,7 @@ import re
 import stat
 import subprocess
 import sys
+import tempfile
 
 from .state import STATE
 
@@ -105,6 +106,15 @@ def log_command_safe(args, env, log=None):
     if log is None:
         log = logging
     log.info('Executing command: %r, environment: %r', args, env)
+
+
+def write_password(password, host):
+    pfile = tempfile.mkstemp(suffix='.v2v')
+    STATE.internal['password_files'].append(pfile[1])
+    os.fchown(pfile[0], host.get_uid(), host.get_gid())
+    os.write(pfile[0], bytes(password.encode('utf-8')))
+    os.close(pfile[0])
+    return pfile[1]
 
 
 def add_perms_to_file(path, modes, uid=-1, gid=-1):

--- a/wrapper/state.py
+++ b/wrapper/state.py
@@ -99,6 +99,7 @@ class _State(StateObject):
             'display_name': None,
             'ports': [],
             'duplicate_logs': False,
+            'password_files': []
         }
         self.last_message = None
         self.pid = None


### PR DESCRIPTION
The `write_password` method could be used outside of `virt-v2v-wrapper.py`, for example to create the oVirt password file during `validate_data` method in `host.py`. This pull request moves it to `common.py` and updates existing calls. It also stores the password files paths to `STATE.internal['password_files']` to have central place accessible from all classes.