### PR TITLE
Warm conversion

### DIFF
--- a/wrapper/hosts.py
+++ b/wrapper/hosts.py
@@ -661,7 +661,7 @@ class OvirtHost(_BaseHost):
 
         for i, pc_disk in enumerate(STATE.pre_copy.disks):
             dt = datetime.datetime.now(datetime.timezone.utc).ctime()
-            name = '%s_Disk%d' % (data['vm_name'], i)
+            name = '%s_Disk%d' % (data['vm_name'], i + 1)
             logging.debug('Creating disk #%d: "%s"', i, name)
             disk = self.sdk.types.Disk(
                 name=name,

--- a/wrapper/pre_copy.py
+++ b/wrapper/pre_copy.py
@@ -184,8 +184,10 @@ class _VMWare(object):
         cred_info = [[libvirt.VIR_CRED_AUTHNAME, libvirt.VIR_CRED_PASSPHRASE],
                      auth_cb, None]
         conn = libvirt.openAuth(self._uri, cred_info)
+        domxml = conn.lookupByName(self._vm_name).XMLDesc()
+        logging.debug('Fetched domxml: \n%s', domxml)
 
-        return conn.lookupByName(self._vm_name).XMLDesc()
+        return domxml
 
     def get_disks_from_config(self, config):
         return [x for x in config.hardware.device

--- a/wrapper/pre_copy.py
+++ b/wrapper/pre_copy.py
@@ -443,8 +443,12 @@ class PreCopy(StateObject):
                 self.path = path
                 self.fixed = False
 
+            def __repr__(self):
+                return 'DiskToFix(path=%s, fixed=%s)' % (self.path, self.fixed)
+
         disk_map = {disk.path: DiskToFix(disk.local_path)
                     for disk in self.disks}
+        logging.debug('Fixing disks with disk map: %s', disk_map)
         tree = ETree.fromstring(domxml)
         for disk in tree.find('devices').findall('disk'):
             src = disk.find('source')

--- a/wrapper/pre_copy.py
+++ b/wrapper/pre_copy.py
@@ -217,8 +217,8 @@ class _VMWare(object):
                  if isinstance(x, vim.vm.device.VirtualDisk) and x.key == key]
         if len(disks) != 1:
             raise RuntimeError('Integrity error: '
-                               'Cannot find disk with key %s' %
-                               key)
+                               'Number of disks with key %s: %d' %
+                               (key, len(disks)))
         return disks[0]
 
     def create_snapshot(self):
@@ -227,9 +227,9 @@ class _VMWare(object):
         WaitForTask(vm.CreateSnapshot(name='v2v_cbt',
                                       description='Snapshot to start CBT',
                                       memory=False,
-                                      # The `quesce` parameter can be False to
+                                      # The `quiesce` parameter can be False to
                                       # make it slightly faster, but it should
-                                      # ve first tested independently.
+                                      # be first tested independently.
                                       quiesce=True))
         # Update the VM data
         vm = self.get_vm()

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -410,8 +410,13 @@ def validate_data(host, data):
     else:
         data['network_mappings'] = []
 
+    if 'warm' not in data:
+        data['warm'] = False
     if 'two_phase' not in data:
-        data['two_phase'] = False
+        data['two_phase'] = data['warm']
+    elif data['warm'] and not data['two_phase']:
+        hard_error('Cannot disable two-phase conversion '
+                   'when warm conversion is requested')
 
     host.validate_data(data)
     STATE.pre_copy = PreCopy(data)


### PR DESCRIPTION
There are few different changes in this:

* we are not throwing away the logs from nbdkits

* we are requesting list of allocated extents of disks using pyvmomi

* block stats are not requested for the whole disk, but rather only for those
  extents that have data

* there's a new function `copy_ref` that helps us refer to the right copy
  instance from the list of copies based on whether this is the final copy
  (which was the only one in two-phase conversion) or an "intermediate" or
  "warm" copy

* there are some fixes implemented, for example closing the file and the nbd
  handle upon failure, removal of some unused class members, cleaning up of
  nbdkit sockets and simplification of vmware_password_file being passed around

Signed-off-by: Martin Kletzander <mkletzan@redhat.com>