### PR TITLE
travis: Disable tox spinner for parallel builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ addons:
 install:
   - pip install tox
 
+env:
+  global:
+    - TOX_PARALLEL_NO_SPINNER=1
+
 script:
   # Run syntax checks and linters
   - tox -p all


### PR DESCRIPTION
The output is nicer in files where the carriage returns (`\r`s) don't do what they do in the terminal.

Signed-off-by: Martin Kletzander <mkletzan@redhat.com>