### PR TITLE
Update regexp for nbdkit disk path

### DIFF
--- a/wrapper/log_parser.py
+++ b/wrapper/log_parser.py
@@ -13,7 +13,7 @@ class OutputParser(object):
     COPY_DISK_RE = re.compile(br'.*Copying disk (\d+)/(\d+) to.*')
     DISK_PROGRESS_RE = re.compile(br'\s+\((\d+\.\d+)/100%\)')
     NBDKIT_DISK_PATH_RE = re.compile(
-        br'nbdkit: debug: Opening file (.*) \(.*\)')
+        br'nbdkit: .*: debug: Opening file (.*) \(.*\)')
     OVERLAY_SOURCE_RE = re.compile(
         br' *overlay source qemu URI: json:.*"file\.path": ?"([^"]+)"')
     OVERLAY_SOURCE2_RE = re.compile(

--- a/wrapper/log_parser.py
+++ b/wrapper/log_parser.py
@@ -13,7 +13,7 @@ class OutputParser(object):
     COPY_DISK_RE = re.compile(br'.*Copying disk (\d+)/(\d+) to.*')
     DISK_PROGRESS_RE = re.compile(br'\s+\((\d+\.\d+)/100%\)')
     NBDKIT_DISK_PATH_RE = re.compile(
-        br'nbdkit: .*: debug: Opening file (.*) \(.*\)')
+        br'nbdkit:.* debug: Opening file (.*) \(.*\)')
     OVERLAY_SOURCE_RE = re.compile(
         br' *overlay source qemu URI: json:.*"file\.path": ?"([^"]+)"')
     OVERLAY_SOURCE2_RE = re.compile(

--- a/wrapper/tests/test_output_parser.py
+++ b/wrapper/tests/test_output_parser.py
@@ -62,7 +62,7 @@ class TestOutputParser(unittest.TestCase):
     def test_rhv_disk_path_vddk(self):
         with wrapper.log_parser() as parser:
             parser.parse_line(
-                b'nbdkit: debug: Opening file [store1] /path1.vmdk (ha-nfcssl://[store1] path1.vmdk@1.2.3.4:902)')  # NOQA
+                b'nbdkit: vddk[1]: debug: Opening file [store1] /path1.vmdk (ha-nfcssl://[store1] path1.vmdk@1.2.3.4:902)')  # NOQA
             self.assertEqual(parser._current_path, '[store1] /path1.vmdk')
 
     def test_rhv_disk_uuid(self):


### PR DESCRIPTION
The log format of virt-v2v has changed and it now contains the transport method, as well the disk number. This breaks the progress reporting in state file. This pull request updates the regular expression.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1810040