### PR TITLE
Write the state file early

### DIFF
--- a/wrapper/common.py
+++ b/wrapper/common.py
@@ -85,6 +85,12 @@ def hard_error(msg):
     logging.error(msg)
     sys.stderr.write(msg)
     sys.stderr.write('\n')
+    if STATE is not None and STATE.state_file is not None:
+        STATE.last_message = {
+            'message': msg,
+            'type': 'error'
+        }
+        STATE.write()
     sys.exit(1)
 
 

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -252,6 +252,7 @@ def main():
     STATE.machine_readable_log = os.path.join(LOG_DIR, 'virt-v2v-mr.log')
     STATE.wrapper_log = os.path.join(LOG_DIR, 'virt-v2v-wrapper.log')
     STATE.state_file = os.path.join(RUN_DIR, 'state.json')
+    STATE.write()
 
     log_format = '%(asctime)s:%(levelname)s:' \
         + ' %(message)s (%(module)s:%(lineno)d)'


### PR DESCRIPTION
Recently, we've seen some failures in migration check, such as VM already existing in destination. While it's normal to perform checks before transferring disks, the problem is that the state file doesn't exist at that moment and this prevents reporting errors outside of logs.

This pull request make virt-v2v-wrapper create the state file earlier, i.e. right after getting the host.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1809033

