### PR TITLE
OpenStack-to-OpenStack migration review

### DIFF
--- a/docs/Virt-v2v-wrapper.md
+++ b/docs/Virt-v2v-wrapper.md
@@ -71,7 +71,7 @@ point the following key is mandatory:
 * `conversion_host_uuid`: the UUID of a VM in which the actual conversion is
   being performed.
 
-Output configuration: reffer to the section [Output
+Output configuration: refer to the section [Output
 configuration](#output-configuration) below.
 
 Miscellaneous:
@@ -106,6 +106,16 @@ The migration works by attaching volumes to the source and destination
 conversion hosts and transferring data from inside the conversion hosts over
 SSH.
 
+Currently, both source and destination conversion hosts expect to run inside a
+Universal Conversion Image (UCI) provided by this project:
+https://github.com/ManageIQ/manageiq-v2v-conversion_host-build
+
+Specifically, the appliance version of the UCI should be uploaded to source and
+destination OpenStack clouds as an image, and conversion host instances should
+be created from those images. Log in as `cloud-user` and check the output of
+`sudo podman images`. There should be a pre-configured container named
+`v2v-conversion-host` that contains the actual V2V-wrapper tooling.
+
 ### Source OpenStack cloud
 
 * A conversion host instance must be launched from the UCI, in the same project
@@ -117,8 +127,7 @@ from the destination OpenStack cloud.
 * The conversion host instance must have SSH enabled in the security rules.
 * The conversion host instance must be configured for key-based SSH access from
 the destination conversion host instance (see input arguments below).
-* The source VM must be shut down. If it is not already shut down, the wrapper
-will shut it down forcibly before proceeding with the transfer.
+* The source VM must be shut down.
 * If the source VM is launched from a volume, there must be space in the
 project's quota for one snapshot of that volume, and for one new volume to be
 created from that snapshot.
@@ -134,55 +143,44 @@ VM's flavor specification).
 virt-v2v requires.
 * The destination conversion host must be configured to be able to log in to
 the source conversion host instance with an SSH key. The key can be specified
-in the `ssh_key` input argument, or stored in /home/cloud-user/.ssh.
+in the `ssh_key` input argument, or stored in /home/cloud-user/.ssh. In
+addition, the `transport_method` input argument must be set to `ssh`.
 
 ### OpenStack-specific inputs
 
 To initiate an OpenStack migration, the input file must have the following keys
 set:
-
-* `vm_name`: The name of the migrated VM on the destination side
-* `transport_method`: Must be set to "ssh" for OpenStack-to-OpenStack migration
-* `osp_environment`: Contains the usual OpenStack destination arguments, passed
-to the openstack command through virt-v2v. Each subkey must be prefixed with
-'os-'.
-* `osp_destination_project_id`: The ID of the receiving project on the
-destination OpenStack side.
-* `osp_flavor_id`: The flavor to use to create the new VM on the destination
-OpenStack side, after all volumes are transferred.
-* `osp_security_group_ids`: A list of IDs of the security groups that should be
-applied to the new VM on the destination.
-* `osp_server_id`: The ID of the destination conversion host.
-* `insecure_connection`: Set to true or false to decide whether or not the
-certificate of the destination OpenStack API should be verified.
-* `source_disks`: Optional list of volume IDs to include in the transfer.
-Without this, the wrapper will transfer all volumes connected to the source VM.
-If this is set, the wrapper will only transfer the connected volumes that are
-included in this list. Volumes that are included in this list but not connected
-to the target VM will not be included in the transfer.
-* `ssh_key`: An OpenSSH private key that is authorized on the source and
-destination conversion host instances. Optional, but if this is missing then
-care must be taken to authorize the destination conversion host's private key
-on the source conversion host. The destination conversion host will expect to
-have password-less SSH to the source conversion host!
+* `osp_source_vm_id`: The ID of the target VM to copy from the OpenStack source
+* `osp_source_conversion_vm_id`: The ID of the source conversion host instance
 * `osp_source_environment`: A set of sub-items to organize arguments for the
 source OpenStack cloud.
-  * `vm_id`: The ID of the target VM to migrate from the OpenStack source
-  * `conversion_vm_id`: The ID of the source conversion host instance
-  * `auth_url`: Public keystone URL for access to the OpenStack API
-  * `username`: Source OpenStack username. Currently only username/password
-  logins are supported for the source side.
-  * `password`: Source OpenStack password
-  * `user_domain_name`: Source OpenStack user domain
-  * `project_name`: Name of project containing source conversion host instance
-  * `project_domain_name`: Domain name of source project
-  * `verify`: Verify source OpenStack API certificate (true or false)
+  * `os-auth_url`: Public keystone URL for access to the OpenStack API
+  * `os-username`: Source OpenStack username. Currently only username/password
+  log-ins are supported for the source side.
+  * `os-password`: Source OpenStack password
+  * `os-user_domain_name`: Source OpenStack user domain
+  * `os-project_name`: Name of project containing source conversion host instance
+  * `os-project_domain_name`: Domain name of source project
+  * `os-verify`: Verify source OpenStack API certificate (true or false)
+* `uci_container`: The ID of the virt-v2v-wrapper container inside the UCI on
+the source conversion host. This is needed so that the destination conversion
+host can run the second copy of the wrapper on the source. This defaults to
+`v2v-conversion-host`, which may not always match different builds of the UCI.
+
+Currently OpenStack source clouds can only be migrated to an OpenStack
+destination, so a full input JSON needs to include the OpenStack input
+parameters specified in `Openstack output` below.
 
 Example:
 
 	{
 		"vm_name": "migration-vm",
 		"transport_method": "ssh",
+		"insecure_connection": true,
+		"osp_destination_project_id": "46deadaba9234ed4bef28caa459bdd16",
+		"osp_flavor_id": "a96b2815-3525-4eea-9ab4-14ba58e17835",
+		"osp_security_groups_ids": ["d5366f19-c34f-493c-a816-b305085c8fae"],
+		"osp_server_id": "b9ca0b1b-0eba-45c4-8c0b-4f27457b72be",
 		"osp_environment": {
 			"os-auth_url": "http://192.168.55.9:5000/v3",
 			"os-username": "migration-user",
@@ -191,22 +189,17 @@ Example:
 			"os-project_domain_name": "Default",
 			"os-user_domain_name": "Default"
 		},
-		"osp_destination_project_id": "46deadaba9234ed4bef28caa459bdd16",
-		"osp_flavor_id": "a96b2815-3525-4eea-9ab4-14ba58e17835",
-		"osp_security_groups_ids": ["d5366f19-c34f-493c-a816-b305085c8fae"],
-		"osp_server_id": "b9ca0b1b-0eba-45c4-8c0b-4f27457b72be",
-		"insecure_connection": true,
+		"osp_source_vm_id": "c28d5a15-0372-4222-95d3-13055f3c6a9b",
+		"osp_source_conversion_vm_id": "5143dba7-c8ac-4230-ac9a-dbd21788f209"
 		"osp_source_environment": {
-			"auth_url": "http://192.168.75.19:5000/v3",
-			"username": "new-migration-user",
-			"password": "migrate",
-			"project_name": "migration-source",
-			"project_domain_name": "Default",
-			"user_domain_name": "Default",
-			"verify": false,
-			"vm_id": "c28d5a15-0372-4222-95d3-13055f3c6a9b",
-			"conversion_vm_id": "5143dba7-c8ac-4230-ac9a-dbd21788f209"
+			"os-auth_url": "http://192.168.75.19:5000/v3",
+			"os-username": "new-migration-user",
+			"os-password": "migrate",
+			"os-project_name": "migration-source",
+			"os-project_domain_name": "Default",
+			"os-user_domain_name": "Default",
 		},
+		"uci_container": "v2v-conversion-host-rhel8",
 		"ssh_key": "-----BEGIN OPENSSH PRIVATE KEY-----\n...\n...\n-----END OPENSSH PRIVATE KEY-----\n"
 	}
 

--- a/docs/Virt-v2v-wrapper.md
+++ b/docs/Virt-v2v-wrapper.md
@@ -190,14 +190,14 @@ Example:
 			"os-user_domain_name": "Default"
 		},
 		"osp_source_vm_id": "c28d5a15-0372-4222-95d3-13055f3c6a9b",
-		"osp_source_conversion_vm_id": "5143dba7-c8ac-4230-ac9a-dbd21788f209"
+		"osp_source_conversion_vm_id": "5143dba7-c8ac-4230-ac9a-dbd21788f209",
 		"osp_source_environment": {
 			"os-auth_url": "http://192.168.75.19:5000/v3",
 			"os-username": "new-migration-user",
 			"os-password": "migrate",
 			"os-project_name": "migration-source",
 			"os-project_domain_name": "Default",
-			"os-user_domain_name": "Default",
+			"os-user_domain_name": "Default"
 		},
 		"uci_container": "v2v-conversion-host-rhel8",
 		"ssh_key": "-----BEGIN OPENSSH PRIVATE KEY-----\n...\n...\n-----END OPENSSH PRIVATE KEY-----\n"

--- a/docs/Virt-v2v-wrapper.md
+++ b/docs/Virt-v2v-wrapper.md
@@ -162,7 +162,7 @@ source OpenStack cloud.
   * `os-project_name`: Name of project containing source conversion host instance
   * `os-project_domain_name`: Domain name of source project
   * `os-verify`: Verify source OpenStack API certificate (true or false)
-* `uci_container`: The ID of the virt-v2v-wrapper container inside the UCI on
+* `uci_container_image`: The ID of the virt-v2v-wrapper container image inside the UCI on
 the source conversion host. This is needed so that the destination conversion
 host can run the second copy of the wrapper on the source. This defaults to
 `v2v-conversion-host`, which may not always match different builds of the UCI.
@@ -199,7 +199,7 @@ Example:
 			"os-project_domain_name": "Default",
 			"os-user_domain_name": "Default"
 		},
-		"uci_container": "v2v-conversion-host-rhel8",
+		"uci_container_image": "v2v-conversion-host-rhel8",
 		"ssh_key": "-----BEGIN OPENSSH PRIVATE KEY-----\n...\n...\n-----END OPENSSH PRIVATE KEY-----\n"
 	}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ libvirt-python
 pyvmomi
 packaging
 python-openstackclient
+openstacksdk

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     install_requires=[
         'pycurl',
         'libvirt-python',
+        'openstacksdk',
         'pyvmomi',
         'packaging',
         # TODO: Uncomment this when it becomes available in pypi and also do

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
     install_requires=[
         'pycurl',
         'libvirt-python',
-        'openstacksdk',
         'pyvmomi',
         'packaging',
         # TODO: Uncomment this when it becomes available in pypi and also do

--- a/wrapper/exports.py
+++ b/wrapper/exports.py
@@ -1,0 +1,85 @@
+""" Block device exports
+
+Methods for exporting block devices from a standalone wrapper instance. The UCI
+is set up to immediately run virt-v2v-wrapper with JSON input, so the easiest
+way to run a sub-process for nbdkit is to have that input trigger this module.
+So if the JSON contains an 'nbd_export_only' object, the wrapper will just run
+the export_nbd function.
+
+The initial use case is migration from OpenStack, which has a UCI container
+running inside a source migration VM. The migration destination wrapper will
+connect to the migration source host and tell it to run the UCI container with
+the nbd_export_only JSON, which will run a function in this module to manage
+the actual nbdkit exports.
+"""
+
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+
+from .source_hosts import NBD_READY_SENTINEL, DEFAULT_TIMEOUT
+
+
+def export_nbd(port_map):
+    """
+    Start one nbdkit process for every disk in the JSON input. Intended to be
+    run inside a UCI container inside a source conversion host.
+    """
+    log_format = '%(asctime)s:%(levelname)s:' \
+        + ' %(message)s (%(module)s:%(lineno)d)'
+    logging.basicConfig(
+        level=logging.DEBUG,
+        filename='/data/virt-v2v-wrapper.log',
+        filemode='w',
+        format=log_format)
+    logger = logging.getLogger()
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    logger.addHandler(stdout_handler)
+    logger.addHandler(stderr_handler)
+    logging.info('Starting up, map is %s', str(port_map))
+
+    # Start one nbdkit process per disk, using the port specified in the map
+    processes = {}
+    for disk, port in port_map.items():
+        logging.info('Exporting %s over NBD, port %s', disk, str(port))
+        cmd = ['nbdkit', '--exit-with-parent', '-p', str(port), 'file', disk]
+        processes[disk] = subprocess.Popen(cmd)
+
+    # Check qemu-img info on all the disks to make sure everything is ready
+    logging.info('Waiting for valid qemu-img info on all exports...')
+    for second in range(DEFAULT_TIMEOUT):
+        try:
+            for disk, port in port_map.items():
+                cmd = ['qemu-img', 'info', 'nbd://localhost:{}'.format(port)]
+                image_info = subprocess.check_output(cmd)
+                logging.info('qemu-img info for %s: %s', disk, image_info)
+        except Exception as error:
+            logging.info('Got exception: %s', error)
+            logging.info('Trying again.')
+            time.sleep(1)
+        else:
+            logging.info('All volume exports ready.')
+            break
+    else:
+        raise RuntimeError('Timed out starting nbdkit exports!')
+
+    # Signal readiness by writing out an 'nbdready' file. The wrapper running
+    # on the destination conversion host will poll for this file before trying
+    # to do anything with the NBD export URL.
+    sentinel = os.path.join('/data', NBD_READY_SENTINEL)
+    with open(sentinel, 'w') as ready:
+        ready.write('NBD exports ready')
+
+    # Wait until told to stop
+    signal.pause()
+    logging.info('Got a stop signal, cleaning up...')
+    for disk, process in processes.items():
+        process.terminate()
+        out, err = process.communicate()
+        logging.info('Output from %s: %s', disk, out)
+        logging.info('Errors from %s: %s', disk, err)

--- a/wrapper/exports.py
+++ b/wrapper/exports.py
@@ -13,7 +13,6 @@ the nbd_export_only JSON, which will run a function in this module to manage
 the actual nbdkit exports.
 """
 
-import json
 import logging
 import os
 import signal

--- a/wrapper/hosts.py
+++ b/wrapper/hosts.py
@@ -609,7 +609,7 @@ class OpenstackHost(_BaseHost):
 
         servers = self._run_openstack(['server', 'list',
                                        '-f', 'value', '-c', 'Name'],
-                                      data)
+                                      data).split()
         if data['vm_name'] in servers:
             hard_error('VM with the name "%s" already exists on the '
                        'destination' % data['vm_name'])

--- a/wrapper/hosts.py
+++ b/wrapper/hosts.py
@@ -674,6 +674,8 @@ class OpenstackHost(_BaseHost):
             logging.error(
                 'Command exited with non-zero return code %d, output:\n%s\n',
                 e.returncode, e.output)
+            if e.stderr:
+                logging.error('Contents of stderr:\n%s\n', e.stderr)
             return None
         if output.stderr:
             logging.warn('Command ran successfully, but '

--- a/wrapper/source_hosts.py
+++ b/wrapper/source_hosts.py
@@ -14,6 +14,7 @@ because those aren't supposed to use virt-v2v - in this case, this module will
 transfer the data itself instead of calling the main wrapper function.
 """
 
+import errno
 import fcntl
 import json
 import logging
@@ -28,8 +29,8 @@ from .state import STATE, Disk
 from .pre_copy import PreCopy
 
 
-NBD_READY_SENTINEL = 'nbdready' # Created when nbdkit exports are ready
-DEFAULT_TIMEOUT = 600           # Maximum wait for openstacksdk operations
+NBD_READY_SENTINEL = 'nbdready'  # Created when nbdkit exports are ready
+DEFAULT_TIMEOUT = 600            # Maximum wait for openstacksdk operations
 
 # Lock to serialize volume attachments. This helps prevent device path
 # mismatches between the OpenStack SDK and /dev in the VM.
@@ -45,6 +46,31 @@ def detect_source_host(data, agent_sock):
     if 'osp_source_environment' in data:
         return OpenStackSourceHost(data, agent_sock)
     return None
+
+
+def _use_lock(lock_file):
+    """ Boilerplate for functions that need to take a lock. """
+    def _decorate_lock(function):
+        def wait_for_lock(self):
+            with open(lock_file, 'wb+') as lock:
+                for second in range(DEFAULT_TIMEOUT):
+                    try:
+                        logging.info('Waiting for lock %s...', lock_file)
+                        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                        break
+                    except OSError:
+                        logging.info('Another conversion has the lock.')
+                        time.sleep(1)
+                else:
+                    raise RuntimeError(
+                        'Unable to acquire lock {}!'.format(lock_file))
+                try:
+                    function(self)
+                finally:
+                    fcntl.flock(lock, fcntl.LOCK_UN)
+        return wait_for_lock
+    return _decorate_lock
+
 
 class _BaseSourceHost(object):
     """ Interface for source hosts. """
@@ -67,18 +93,20 @@ class _BaseSourceHost(object):
         return True
 
 
-VolumeMapping = namedtuple('VolumeMapping',
-    ['source_dev', # Device path (like /dev/vdb) on source conversion host
-     'source_id', # Volume ID on source conversion host
-     'dest_dev', # Device path on destination conversion host
-     'dest_id', # Volume ID on destination conversion host
-     'snap_id', # Root volumes need snapshot+new volume, so record snapshot ID
-     'image_id', # Direct-from-image VMs create this temporary snapshot image
-     'name', # Save volume name so root volumes don't look weird on destination
-     'size', # Volume size reported by OpenStack, in GB
-     'url', # Final NBD export address from source conversion host
-     'state' # STATE.Disk object for tracking progress
-    ])
+VolumeMapping = namedtuple('VolumeMapping', [
+    'source_dev',  # Device path (like /dev/vdb) on source conversion host
+    'source_id',   # Volume ID on source conversion host
+    'dest_dev',    # Device path on destination conversion host
+    'dest_id',     # Volume ID on destination conversion host
+    'snap_id',     # Root volumes need snapshot+new volume
+    'image_id',    # Direct-from-image VMs create temporary snapshot image
+    'name',        # Save volume name to set on destination
+    'size',        # Volume size reported by OpenStack, in GB
+    'url',         # Final NBD export address from source conversion host
+    'state'        # STATE.Disk object for tracking progress
+])
+
+
 class OpenStackSourceHost(_BaseSourceHost):
     """ Export volumes from an OpenStack instance. """
 
@@ -98,7 +126,7 @@ class OpenStackSourceHost(_BaseSourceHost):
                         'os-project_name', 'os-project_domain_name',
                         'os-user_domain_name']
         osp_env = data['osp_environment']
-        osp_args = {arg[3:]: osp_env[arg] for arg in osp_arg_list} # Trim 'os-'
+        osp_args = {arg[3:]: osp_env[arg] for arg in osp_arg_list}  # Trim os-
         self.dest_converter = data['osp_server_id']
         if 'insecure_connection' in data:
             osp_args['verify'] = not data['insecure_connection']
@@ -107,7 +135,7 @@ class OpenStackSourceHost(_BaseSourceHost):
         self.dest_conn = openstack.connect(**osp_args)
 
         self.agent_sock = agent_sock
-        openstack.enable_logging() # Lots of openstacksdk messages without this
+        openstack.enable_logging()  # Make openstacksdk logging quieter
 
         # Build up a list of VolumeMappings keyed by the original device path
         self.volume_map = {}
@@ -169,7 +197,7 @@ class OpenStackSourceHost(_BaseSourceHost):
         """ Provide default set of SSH options. """
         return [
             '-o', 'BatchMode=yes',
-            '-o', 'StrictHostKeyChecking=no', 
+            '-o', 'StrictHostKeyChecking=no',
             '-o', 'ConnectTimeout=10',
         ]
 
@@ -217,7 +245,7 @@ class OpenStackSourceHost(_BaseSourceHost):
         command = ['scp']
         command.extend(self._ssh_args())
         command.extend([source, 'cloud-user@'+address+':'+dest])
-        return subprocess.check_output(command, env=environment)
+        return subprocess.call(command, env=environment)
 
     def _converter_scp_from(self, source, dest, recursive=False):
         """ Copy a file from the source conversion host. """
@@ -229,7 +257,7 @@ class OpenStackSourceHost(_BaseSourceHost):
         if recursive:
             command.extend(['-r'])
         command.extend(['cloud-user@'+address+':'+source, dest])
-        return subprocess.check_output(command, env=environment)
+        return subprocess.call(command, env=environment)
 
     def _test_ssh_connection(self):
         """ Quick SSH connectivity check for source conversion host. """
@@ -244,7 +272,7 @@ class OpenStackSourceHost(_BaseSourceHost):
             self.conn.compute.stop_server(server=server)
             logging.info('Waiting for source VM to stop...')
             self.conn.compute.wait_for_server(server, 'SHUTOFF',
-                wait=DEFAULT_TIMEOUT)
+                                              wait=DEFAULT_TIMEOUT)
 
     def _get_attachment(self, volume, vm):
         """
@@ -271,10 +299,10 @@ class OpenStackSourceHost(_BaseSourceHost):
                 continue
             dev_path = self._get_attachment(volume, sourcevm).device
             disk = Disk(dev_path, 0)
-            self.volume_map[dev_path] = VolumeMapping(source_dev=None,
-                source_id=volume.id, dest_dev=None, dest_id=None, snap_id=None,
-                image_id=None, name=volume.name, size=volume.size, url=None,
-                state=disk)
+            self.volume_map[dev_path] = VolumeMapping(
+                source_dev=None, source_id=volume.id, dest_dev=None,
+                dest_id=None, snap_id=None, image_id=None, name=volume.name,
+                size=volume.size, url=None, state=disk)
             STATE.disks.append(disk)
             logging.debug('STATE.disks is now %s', STATE.disks)
             STATE.write()
@@ -295,17 +323,17 @@ class OpenStackSourceHost(_BaseSourceHost):
 
             # Create a snapshot of the root volume
             logging.info('Creating root device snapshot')
-            root_snapshot = self.conn.create_volume_snapshot(force=True,
-                wait=True, name='rhosp-migration-{}'.format(volume_id),
-                volume_id=volume_id, timeout=DEFAULT_TIMEOUT)
+            root_snapshot = self.conn.create_volume_snapshot(
+                force=True, wait=True, volume_id=volume_id,
+                name='rhosp-migration-{}'.format(volume_id),
+                timeout=DEFAULT_TIMEOUT)
 
             # Create a new volume from the snapshot
             logging.info('Creating new volume from root snapshot')
-            root_volume_copy = self.conn.create_volume(wait=True,
-                    name='rhosp-migration-{}'.format(volume_id),
-                    snapshot_id=root_snapshot.id,
-                    size=root_snapshot.size,
-                    timeout=DEFAULT_TIMEOUT)
+            root_volume_copy = self.conn.create_volume(
+                wait=True, name='rhosp-migration-{}'.format(volume_id),
+                snapshot_id=root_snapshot.id, size=root_snapshot.size,
+                timeout=DEFAULT_TIMEOUT)
 
             # Update the volume map with the new volume ID
             self.volume_map['/dev/vda'] = mapping._replace(
@@ -313,24 +341,25 @@ class OpenStackSourceHost(_BaseSourceHost):
                 snap_id=root_snapshot.id)
         elif sourcevm.image:
             logging.info('Image-based instance, creating snapshot...')
-            image = self.conn.compute.create_server_image(server=sourcevm.id,
-                name='rhosp-migration-root-{}'.format(sourcevm.name))
+            image = self.conn.compute.create_server_image(
+                name='rhosp-migration-root-{}'.format(sourcevm.name),
+                server=sourcevm.id)
             for second in range(DEFAULT_TIMEOUT):
                 refreshed_image = self.conn.get_image_by_id(image.id)
                 if refreshed_image.status == 'active':
                     break
                 time.sleep(1)
             else:
-                raise RuntimeError('Could not create new image of image-based '
-                    'instance!')
-            volume = self.conn.create_volume(image=image.id, bootable=True,
-                wait=True, timeout=DEFAULT_TIMEOUT, size=image.min_disk,
-                name=image.name)
+                raise RuntimeError(
+                    'Could not create new image of image-based instance!')
+            volume = self.conn.create_volume(
+                image=image.id, bootable=True, wait=True, name=image.name,
+                timeout=DEFAULT_TIMEOUT, size=image.min_disk)
             disk = Disk('/dev/vda', 0)
-            self.volume_map['/dev/vda'] = VolumeMapping(source_dev=None,
-                source_id=volume.id, dest_dev=None, dest_id=None, snap_id=None,
-                image_id=image.id, name=volume.name, size=volume.size,
-                url=None, state=disk)
+            self.volume_map['/dev/vda'] = VolumeMapping(
+                source_dev=None, source_id=volume.id, dest_dev=None,
+                dest_id=None, snap_id=None, image_id=image.id,
+                name=volume.name, size=volume.size, url=None, state=disk)
             STATE.disks.append(disk)
             logging.debug('STATE.disks is now %s', STATE.disks)
             STATE.write()
@@ -338,14 +367,12 @@ class OpenStackSourceHost(_BaseSourceHost):
             raise RuntimeError('No known boot device found for this instance!')
 
         for path, mapping in self.volume_map.items():
-            if path == '/dev/vda':
-                continue
-            else: # Detach non-root volumes
+            if path != '/dev/vda':  # Detach non-root volumes
                 volume_id = mapping.source_id
                 volume = self.conn.get_volume_by_id(volume_id)
                 logging.info('Detaching %s from %s', volume.id, sourcevm.id)
                 self.conn.detach_volume(server=sourcevm, volume=volume,
-                    wait=True, timeout=DEFAULT_TIMEOUT)
+                                        wait=True, timeout=DEFAULT_TIMEOUT)
 
     def _wait_for_volume_dev_path(self, conn, volume, vm, timeout):
         volume_id = volume.id
@@ -358,8 +385,7 @@ class OpenStackSourceHost(_BaseSourceHost):
             time.sleep(1)
         raise RuntimeError('Timed out waiting for volume device path!')
 
-    def _attach_volumes(self, conn, host_func, name, ssh_func, update_func,
-            volume_id_func):
+    def _attach_volumes(self, conn, name, funcs):
         """
         Attach all volumes in the volume map to the specified conversion host.
         Check the list of disks before and after attaching to be absolutely
@@ -368,24 +394,25 @@ class OpenStackSourceHost(_BaseSourceHost):
         _attach_volumes_to_converter looked almost identical.
         """
         logging.info('Attaching volumes to %s wrapper', name)
+        host_func, ssh_func, update_func, volume_id_func = funcs
         for path, mapping in sorted(self.volume_map.items()):
             volume_id = volume_id_func(mapping)
             volume = conn.get_volume_by_id(volume_id)
             logging.info('Attaching %s to %s conversion host', volume_id, name)
 
             disks_before = ssh_func(['lsblk', '--noheadings', '--list',
-                '--paths', '--nodeps', '--output NAME'])
+                                     '--paths', '--nodeps', '--output NAME'])
             disks_before = set(disks_before.split())
             logging.debug('Initial disk list: %s', disks_before)
 
             conn.attach_volume(volume=volume, wait=True, server=host_func(),
-                timeout=DEFAULT_TIMEOUT)
+                               timeout=DEFAULT_TIMEOUT)
             logging.info('Waiting for volume to appear in %s wrapper', name)
             self._wait_for_volume_dev_path(conn, volume, host_func(),
-                DEFAULT_TIMEOUT)
+                                           DEFAULT_TIMEOUT)
 
             disks_after = ssh_func(['lsblk', '--noheadings', '--list',
-                '--paths', '--nodeps', '--output NAME'])
+                                    '--paths', '--nodeps', '--output NAME'])
             disks_after = set(disks_after.split())
             logging.debug('Updated disk list: %s', disks_after)
 
@@ -396,44 +423,24 @@ class OpenStackSourceHost(_BaseSourceHost):
             if len(new_disks) == 1:
                 if dev_path in new_disks:
                     logging.debug('Successfully attached new disk %s, and %s '
-                        'conversion host path agrees with OpenStack.',
-                        dev_path, name)
+                                  'conversion host path matches OpenStack.',
+                                  dev_path, name)
                 else:
                     dev_path = new_disks.pop()
                     logging.debug('Successfully attached new disk %s, but %s '
-                        'conversion host path does not match the result from '
-                        'OpenStack. Using internal device path %s.',
-                        attachment.device, name, dev_path)
+                                  'conversion host path does not match the  '
+                                  'result from OpenStack. Using internal '
+                                  'device path %s.', attachment.device,
+                                  name, dev_path)
             else:
                 raise RuntimeError('Got unexpected disk list after attaching '
-                    'volume to %s conversion host instance. Failing migration '
-                    'procedure to avoid assigning volumes incorrectly. New '
-                    'disks(s) inside VM: {}, disk provided by OpenStack: '
-                    '{}'.format(name, new_disks, dev_path))
+                                   'volume to {} conversion host instance. '
+                                   'Failing migration procedure to avoid '
+                                   'assigning volumes incorrectly. New '
+                                   'disks(s) inside VM: {}, disk provided by '
+                                   'OpenStack: {}'.format(name, new_disks,
+                                                          dev_path))
             self.volume_map[path] = update_func(mapping, dev_path)
-
-    def _use_lock(lock_file):
-        """ Boilerplate for functions that need to take a lock. """
-        def _decorate_lock(function):
-            def wait_for_lock(self):
-                with open(lock_file, 'wb+') as lock:
-                    for second in range(DEFAULT_TIMEOUT):
-                        try:
-                            logging.info('Waiting for lock %s...', lock_file)
-                            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                            break
-                        except OSError as error:
-                            logging.info('Another conversion has the lock.')
-                            time.sleep(1)
-                    else:
-                        raise RuntimeError('Unable to acquire lock %s!',
-                            lock_file)
-                    try:
-                        function(self)
-                    finally:
-                        fcntl.flock(lock, fcntl.LOCK_UN)
-            return wait_for_lock
-        return _decorate_lock
 
     # Lock this part to have a better chance of the OpenStack device path
     # matching the device path seen inside the conversion host.
@@ -445,10 +452,13 @@ class OpenStackSourceHost(_BaseSourceHost):
         """
         def update_source(volume_mapping, dev_path):
             return volume_mapping._replace(source_dev=dev_path)
+
         def volume_id(volume_mapping):
             return volume_mapping.source_id
-        self._attach_volumes(self.conn, self._converter, 'source',
-            self._converter_out, update_source, volume_id)
+
+        self._attach_volumes(self.conn, 'source', (self._converter,
+                                                   self._converter_out,
+                                                   update_source, volume_id))
 
     def _export_volumes_from_converter(self):
         """
@@ -465,10 +475,10 @@ class OpenStackSourceHost(_BaseSourceHost):
 
         # Choose NBD ports for inside the container
         port = 10809
-        port_map = {} # Map device path to port number, for export_nbd
-        reverse_port_map = {} # Map port number to device path, for forwarding
-        nbd_ports = [] # podman arguments for NBD ports
-        device_list = [] # podman arguments for block devices
+        port_map = {}          # Map device path to port number, for export_nbd
+        reverse_port_map = {}  # Map port number to device path, for forwarding
+        nbd_ports = []         # podman arguments for NBD ports
+        device_list = []       # podman arguments for block devices
         for path, mapping in self.volume_map.items():
             volume_id = mapping.source_id
             dev_path = mapping.source_dev
@@ -485,11 +495,10 @@ class OpenStackSourceHost(_BaseSourceHost):
         self._converter_val(['mkdir', '-p', self.tmpdir+'/log'])
         self._converter_val(['mkdir', '-p', self.tmpdir+'/input'])
         ports = json.dumps({'nbd_export_only': port_map})
-        nbd_conversion = '/tmp/nbd_conversion.json'
-        with open(nbd_conversion, 'w+') as conversion:
+        export_input = '/tmp/nbd_conversion.json'
+        with open(export_input, 'w+') as conversion:
             conversion.write(ports)
-        self._converter_scp(nbd_conversion,
-            self.tmpdir+'/input/conversion.json')
+        self._converter_scp(export_input, self.tmpdir+'/input/conversion.json')
 
         # Run UCI on source conversion host. Create a temporary directory to
         # use as the UCI's /data directory so more than one can run at a time.
@@ -500,7 +509,8 @@ class OpenStackSourceHost(_BaseSourceHost):
         ssh_args.extend(['--volume', self.tmpdir+'/lib:/var/lib/uci:z'])
         ssh_args.extend(['--volume', self.tmpdir+'/log:/var/log/uci:z'])
         ssh_args.extend(['--volume',
-            '/opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib'])
+                         '/opt/vmware-vix-disklib-distrib:'
+                         '/opt/vmware-vix-disklib-distrib'])
         ssh_args.extend(nbd_ports)
         ssh_args.extend(device_list)
         ssh_args.extend(['v2v-conversion-host'])
@@ -511,7 +521,7 @@ class OpenStackSourceHost(_BaseSourceHost):
         ssh_args = ['sudo', 'podman', 'port', self.uci_id]
         out = self._converter_out(ssh_args)
         forward_ports = ['-N', '-T']
-        for line in out.split('\n'): # Format: 10809/tcp -> 0.0.0.0:33437
+        for line in out.split('\n'):  # Format: 10809/tcp -> 0.0.0.0:33437
             logging.debug('Forwarding port from podman: %s', line)
             internal_port, _, _ = line.partition('/')
             _, _, external_port = line.rpartition(':')
@@ -525,8 +535,9 @@ class OpenStackSourceHost(_BaseSourceHost):
             # use the same ports for the same NBD volumes. This is worth
             # explaining in detail because otherwise the following arguments
             # may look backwards at first glance.
-            forward_ports.extend(['-L', '{}:localhost:{}'.format(internal_port,
-                external_port)])
+            forward_ports.extend(['-L',
+                                  '{}:localhost:{}'.format(internal_port,
+                                                           external_port)])
             mapping = self.volume_map[path]
             url = 'nbd://localhost:'+internal_port
             self.volume_map[path] = mapping._replace(url=url)
@@ -566,13 +577,12 @@ class OpenStackSourceHost(_BaseSourceHost):
             if self.tmpdir:
                 os.mkdir(SOURCE_LOGS_DIR)
                 self._converter_scp_from(self.tmpdir+'/*', SOURCE_LOGS_DIR,
-                    recursive=True)
-                self._converter_out(['rm', '-rf', self.tmpdir])
+                                         recursive=True)
+                self._converter_out(['sudo', 'rm', '-rf', self.tmpdir])
 
             self.forwarding_process.terminate()
         except Exception as error:
-            pass
-
+            logging.debug('Error closing exports: %s', error)
 
     def _volume_still_attached(self, volume, vm):
         """ Check if a volume is still attached to a VM. """
@@ -590,10 +600,10 @@ class OpenStackSourceHost(_BaseSourceHost):
             logging.info('Inspecting volume %s', volume.id)
             if mapping.source_dev is None:
                 logging.info('Volume is not attached to conversion host, '
-                    'skipping detach.')
+                             'skipping detach.')
                 continue
-            self.conn.detach_volume(server=converter, wait=True,
-                timeout=DEFAULT_TIMEOUT, volume=volume)
+            self.conn.detach_volume(server=converter, volume=volume,
+                                    timeout=DEFAULT_TIMEOUT, wait=True)
             for second in range(DEFAULT_TIMEOUT):
                 converter = self._converter()
                 volume = self.conn.get_volume_by_id(mapping.source_id)
@@ -602,7 +612,7 @@ class OpenStackSourceHost(_BaseSourceHost):
                 time.sleep(1)
             else:
                 raise RuntimeError('Timed out waiting to detach volumes from '
-                    'source conversion host!')
+                                   'source conversion host!')
 
     def _attach_data_volumes_to_source(self):
         """ Clean up the copy of the root volume and reattach data volumes. """
@@ -612,32 +622,34 @@ class OpenStackSourceHost(_BaseSourceHost):
                 # Delete the temporary copy of the source root disk
                 logging.info('Removing copy of root volume')
                 self.conn.delete_volume(name_or_id=mapping.source_id,
-                    wait=True, timeout=DEFAULT_TIMEOUT)
+                                        wait=True, timeout=DEFAULT_TIMEOUT)
 
                 # Remove the root volume snapshot
                 if mapping.snap_id:
                     logging.info('Deleting temporary root device snapshot')
-                    self.conn.delete_volume_snapshot(timeout=DEFAULT_TIMEOUT,
-                        wait=True, name_or_id=mapping.snap_id)
+                    self.conn.delete_volume_snapshot(
+                        timeout=DEFAULT_TIMEOUT, wait=True,
+                        name_or_id=mapping.snap_id)
 
                 # Remove root image copy, for image-launched instances
                 if mapping.image_id:
                     logging.info('Deleting temporary root device image')
-                    self.conn.delete_image(timeout=DEFAULT_TIMEOUT,
-                        wait=True, name_or_id=mapping.image_id)
+                    self.conn.delete_image(
+                        timeout=DEFAULT_TIMEOUT, wait=True,
+                        name_or_id=mapping.image_id)
             else:
                 # Attach data volumes back to source VM
                 volume = self.conn.get_volume_by_id(mapping.source_id)
                 sourcevm = self._source_vm()
                 try:
-                    attachment = self._get_attachment(volume, sourcevm)
+                    self._get_attachment(volume, sourcevm)
                 except RuntimeError:
                     logging.info('Attaching %s back to source VM', volume.id)
-                    self.conn.attach_volume(volume=volume, wait=True,
-                        server=sourcevm, timeout=DEFAULT_TIMEOUT)
+                    self.conn.attach_volume(volume=volume, server=sourcevm,
+                                            wait=True, timeout=DEFAULT_TIMEOUT)
                 else:
                     logging.info('Volume %s is already attached to source VM',
-                        volume.id)
+                                 volume.id)
                     continue
 
     def _create_destination_volumes(self):
@@ -649,9 +661,10 @@ class OpenStackSourceHost(_BaseSourceHost):
         for path, mapping in self.volume_map.items():
             volume_id = mapping.source_id
             volume = self.conn.get_volume_by_id(volume_id)
-            new_volume = self.dest_conn.create_volume(name=mapping.name,
-                bootable=volume.bootable, description=volume.description,
-                size=volume.size, wait=True, timeout=DEFAULT_TIMEOUT)
+            new_volume = self.dest_conn.create_volume(
+                name=mapping.name, bootable=volume.bootable,
+                description=volume.description, size=volume.size, wait=True,
+                timeout=DEFAULT_TIMEOUT)
             self.volume_map[path] = mapping._replace(dest_id=new_volume.id)
             STATE.internal['disk_ids'][path] = new_volume.id
         STATE.write()
@@ -664,10 +677,13 @@ class OpenStackSourceHost(_BaseSourceHost):
         """
         def update_dest(volume_mapping, dev_path):
             return volume_mapping._replace(dest_dev=dev_path)
+
         def volume_id(volume_mapping):
             return volume_mapping.dest_id
-        self._attach_volumes(self.dest_conn, self._destination, 'destination',
-            self._destination_out, update_dest, volume_id)
+
+        self._attach_volumes(self.dest_conn, 'destination',
+                             (self._destination, self._destination_out,
+                              update_dest, volume_id))
 
     def _convert_destination_volumes(self):
         """
@@ -680,15 +696,17 @@ class OpenStackSourceHost(_BaseSourceHost):
             logging.info('Converting source VM\'s %s: %s', path, str(mapping))
             overlay = '/tmp/'+os.path.basename(mapping.dest_dev)+'.qcow2'
 
-            def _log_convert(source_disk, source_format):
+            def _log_convert(source_disk, source_format, mapping):
                 """ Write qemu-img convert progress to the wrapper log. """
                 logging.info('Copying volume data...')
                 cmd = ['qemu-img', 'convert', '-p', '-f', source_format, '-O',
-                        'host_device', source_disk, mapping.dest_dev]
+                       'host_device', source_disk, mapping.dest_dev]
                 # Non-blocking output processing stolen from pre_copy.py
-                img_sub = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL,
-                    universal_newlines=True, bufsize=1)
+                img_sub = subprocess.Popen(cmd,
+                                           stdout=subprocess.PIPE,
+                                           stderr=subprocess.STDOUT,
+                                           stdin=subprocess.DEVNULL,
+                                           universal_newlines=True, bufsize=1)
                 flags = fcntl.fcntl(img_sub.stdout, fcntl.F_GETFL)
                 flags |= os.O_NONBLOCK
                 fcntl.fcntl(img_sub.stdout, fcntl.F_SETFL, flags)
@@ -708,17 +726,17 @@ class OpenStackSourceHost(_BaseSourceHost):
                 logging.info('Conversion return code: %d', img_sub.returncode)
                 if img_sub.returncode != 0:
                     raise RuntimeError('Failed to convert volume!')
-                else: # Just in case qemu-img returned before readline got 100%
-                    mapping.state.progress = 100.0
-                    STATE.write()
+                # Just in case qemu-img returned before readline got to 100%
+                mapping.state.progress = 100.0
+                STATE.write()
 
             try:
                 logging.info('Attempting initial sparsify...')
                 environment = os.environ.copy()
                 environment['LIBGUESTFS_BACKEND'] = 'direct'
 
-                cmd = ['qemu-img', 'create', '-f', 'qcow2', '-b', mapping.url,
-                    overlay]
+                cmd = ['qemu-img', 'create', '-f', 'qcow2',
+                       '-b', mapping.url, overlay]
                 out = subprocess.check_output(cmd)
                 logging.info('Overlay output: %s', out)
                 logging.info('Overlay size: %s', str(os.path.getsize(overlay)))
@@ -726,21 +744,21 @@ class OpenStackSourceHost(_BaseSourceHost):
                 cmd = ['virt-sparsify', '--in-place', overlay]
                 with open(STATE.wrapper_log, 'a') as log_fd:
                     img_sub = subprocess.Popen(cmd,
-                        stdout=log_fd,
-                        stderr=subprocess.STDOUT,
-                        stdin=subprocess.DEVNULL,
-                        env=environment)
+                                               stdout=log_fd,
+                                               stderr=subprocess.STDOUT,
+                                               stdin=subprocess.DEVNULL,
+                                               env=environment)
                     returncode = img_sub.wait()
                     logging.info('Sparsify return code: %d', returncode)
                     if returncode != 0:
                         raise RuntimeError('Failed to convert volume!')
 
-                _log_convert(overlay, 'qcow2')
-            except Exception as error:
+                _log_convert(overlay, 'qcow2', mapping)
+            except Exception:
                 logging.info('Sparsify failed, converting whole device...')
                 if os.path.isfile(overlay):
                     os.remove(overlay)
-                _log_convert(mapping.url, 'raw')
+                _log_convert(mapping.url, 'raw', mapping)
 
     @_use_lock(ATTACH_LOCK_FILE_DESTINATION)
     def _detach_destination_volumes(self):
@@ -749,5 +767,7 @@ class OpenStackSourceHost(_BaseSourceHost):
         for path, mapping in self.volume_map.items():
             volume_id = mapping.dest_id
             volume = self.dest_conn.get_volume_by_id(volume_id)
-            self.dest_conn.detach_volume(volume=volume, wait=True,
-                server=self._destination(), timeout=DEFAULT_TIMEOUT)
+            self.dest_conn.detach_volume(server=self._destination(),
+                                         timeout=DEFAULT_TIMEOUT,
+                                         volume=volume,
+                                         wait=True)

--- a/wrapper/source_hosts.py
+++ b/wrapper/source_hosts.py
@@ -1,0 +1,577 @@
+""" Source hosts
+
+Some migration sources require significant setup before they can export block
+devices with nbdkit. This module holds the code used to set up nbdkit exports
+on such sources.
+
+For example, the current OpenStack export strategy is to shut down the source
+VM, attach its volumes to a source conversion host, and export the volumes from
+inside the conversion host via nbdkit. The OpenStackSourceHost class will take
+care of the process up to this point, and some other class in the regular hosts
+module will take care of copying the data from those exports to their final
+migration destination. There is an exception for KVM-to-KVM migrations though,
+because those aren't supposed to use virt-v2v - in this case, this module will
+transfer the data itself instead of calling the main wrapper function.
+"""
+
+import fcntl
+import json
+import logging
+import openstack
+import os
+import subprocess
+import time
+from collections import namedtuple
+
+
+NBD_READY_SENTINEL = 'nbdready' # Created when nbdkit exports are ready
+DEFAULT_TIMEOUT = 600           # Maximum wait for openstacksdk operations
+
+# Lock to serialize volume attachments. This helps prevent device path
+# mismatches between the OpenStack SDK and /dev in the VM.
+ATTACH_LOCK_FILE_SOURCE = '/var/lock/v2v-source-volume-lock'
+
+# Local directory to copy logs from source conversion host
+SOURCE_LOGS_DIR = '/data/source_logs'
+
+
+def detect_source_host(data, agent_sock):
+    """ Create the right source host object based on the input data. """
+    if 'osp_source_environment' in data:
+        return OpenStackSourceHost(data, agent_sock)
+    return None
+
+class _BaseSourceHost(object):
+    """ Interface for source hosts. """
+
+    def prepare_exports(self):
+        """ Creates the nbdkit exports from the migration source. """
+        logging.info('No preparation needed for this migration source.')
+
+    def close_exports(self):
+        """ Stops the nbdkit exports on the migration source. """
+        logging.info('No cleanup needed for this migration source.')
+
+
+VolumeMapping = namedtuple('VolumeMapping',
+    ['source_dev', # Device path (like /dev/vdb) on source conversion host
+     'source_id', # Volume ID on source conversion host
+     'snap_id', # Root volumes need snapshot+new volume, so record snapshot ID
+     'image_id', # Direct-from-image VMs create this temporary snapshot image
+     'size', # Volume size reported by OpenStack, in GB
+     'url' # Final NBD export address from source conversion host
+    ])
+class OpenStackSourceHost(_BaseSourceHost):
+    """ Export volumes from an OpenStack instance. """
+
+    def __init__(self, data, agent_sock):
+        # Create a connection to the source cloud
+        osp_arg_list = ['auth_url', 'username', 'password',
+                        'project_name', 'project_domain_name',
+                        'user_domain_name', 'verify']
+        osp_env = data['osp_source_environment']
+        osp_args = {arg: osp_env[arg] for arg in osp_arg_list}
+        self.source_converter = osp_env['conversion_vm_id']
+        self.source_instance = osp_env['vm_id']
+        self.conn = openstack.connect(**osp_args)
+
+        self.agent_sock = agent_sock
+        openstack.enable_logging() # Lots of openstacksdk messages without this
+
+        # Build up a list of VolumeMappings keyed by the original device path
+        self.volume_map = {}
+
+        # Temporary directory for logs on source conversion host
+        self.tmpdir = None
+
+        # If there is a specific list of disks to transfer, remember them so
+        # only those disks get transferred.
+        self.source_disks = None
+        if 'source_disks' in data:
+            self.source_disks = data['source_disks']
+
+    def prepare_exports(self):
+        """ Attach the source VM's volumes to the source conversion host. """
+        self._test_ssh_connection()
+        self._shutdown_source_vm()
+        self._get_root_and_data_volumes()
+        self._detach_data_volumes_from_source()
+        self._attach_volumes_to_converter()
+        self._export_volumes_from_converter()
+
+    def close_exports(self):
+        """ Put the source VM's volumes back where they were. """
+        self._test_ssh_connection()
+        self._converter_close_exports()
+        self._detach_volumes_from_converter()
+        self._attach_data_volumes_to_source()
+
+    def _source_vm(self):
+        """
+        Changes to the VM returned by get_server_by_id are not necessarily
+        reflected in existing objects, so just get a new one every time.
+        """
+        return self.conn.get_server_by_id(self.source_instance)
+
+    def _converter(self):
+        """ Same idea as _source_vm, for source conversion host. """
+        return self.conn.get_server_by_id(self.source_converter)
+
+    def _ssh_args(self):
+        """ Provide default set of SSH options. """
+        return [
+            '-o', 'BatchMode=yes',
+            '-o', 'StrictHostKeyChecking=no', 
+            '-o', 'ConnectTimeout=10',
+        ]
+
+    def _ssh_cmd(self, address, args):
+        """ Build an SSH command and environment using the running agent. """
+        environment = os.environ.copy()
+        environment['SSH_AUTH_SOCK'] = self.agent_sock
+        command = ['ssh']
+        command.extend(self._ssh_args())
+        command.extend(['cloud-user@'+address])
+        command.extend(args)
+        return command, environment
+
+    def _converter_out(self, args):
+        """ Run a command on the source conversion host and get the output. """
+        address = self._converter().accessIPv4
+        command, environment = self._ssh_cmd(address, args)
+        output = subprocess.check_output(command, env=environment)
+        return output.decode('utf-8').strip()
+
+    def _converter_val(self, args):
+        """ Run a command on the source conversion host and get return code """
+        address = self._converter().accessIPv4
+        command, environment = self._ssh_cmd(address, args)
+        return subprocess.call(command, env=environment)
+
+    def _converter_sub(self, args):
+        """ Run a long-running command on the source conversion host. """
+        address = self._converter().accessIPv4
+        command, environment = self._ssh_cmd(address, args)
+        return subprocess.Popen(command, env=environment)
+
+    def _converter_scp(self, source, dest):
+        """ Copy a file to the source conversion host. """
+        environment = os.environ.copy()
+        environment['SSH_AUTH_SOCK'] = self.agent_sock
+        address = self._converter().accessIPv4
+        command = ['scp']
+        command.extend(self._ssh_args())
+        command.extend([source, 'cloud-user@'+address+':'+dest])
+        return subprocess.check_output(command, env=environment)
+
+    def _converter_scp_from(self, source, dest, recursive=False):
+        """ Copy a file from the source conversion host. """
+        environment = os.environ.copy()
+        environment['SSH_AUTH_SOCK'] = self.agent_sock
+        address = self._converter().accessIPv4
+        command = ['scp']
+        command.extend(self._ssh_args())
+        if recursive:
+            command.extend(['-r'])
+        command.extend(['cloud-user@'+address+':'+source, dest])
+        return subprocess.check_output(command, env=environment)
+
+    def _test_ssh_connection(self):
+        """ Quick SSH connectivity check for source conversion host. """
+        out = self._converter_out(['echo connected'])
+        if out != 'connected':
+            raise RuntimeError('Unable to SSH to source conversion host!')
+
+    def _shutdown_source_vm(self):
+        """ Shut down the migration source VM before moving its volumes. """
+        server = self.conn.compute.get_server(self._source_vm().id)
+        if server.status != 'SHUTOFF':
+            self.conn.compute.stop_server(server=server)
+            logging.info('Waiting for source VM to stop...')
+            self.conn.compute.wait_for_server(server, 'SHUTOFF',
+                wait=DEFAULT_TIMEOUT)
+
+    def _get_attachment(self, volume, vm):
+        """
+        Get the attachment object from the volume with the matching server ID.
+        Convenience method for use only when the attachment is already certain.
+        """
+        for attachment in volume.attachments:
+            if attachment.server_id == vm.id:
+                return attachment
+        raise RuntimeError('Volume is not attached to the specified instance!')
+
+    def _get_root_and_data_volumes(self):
+        """
+        Volume mapping step one: get the IDs and sizes of all volumes on the
+        source VM. Key off the original device path to eventually preserve this
+        order on the destination.
+        """
+        sourcevm = self._source_vm()
+        for server_volume in sourcevm.volumes:
+            volume = self.conn.get_volume_by_id(server_volume['id'])
+            logging.info('Inspecting volume: %s', volume.id)
+            if self.source_disks and volume.id not in self.source_disks:
+                logging.info('Volume is not in specified disk list, ignoring.')
+                continue
+            dev_path = self._get_attachment(volume, sourcevm).device
+            self.volume_map[dev_path] = VolumeMapping(source_dev=None,
+                source_id=volume.id, snap_id=None,
+                image_id=None, name=volume.name, size=volume.size, url=None)
+
+    def _detach_data_volumes_from_source(self):
+        """
+        Detach data volumes from source VM, and pretend to "detach" the boot
+        volume by creating a new volume from a snapshot of the VM. If the VM is
+        booted directly from an image, take a VM snapshot and create the new
+        volume from that snapshot.
+        Volume map step two: replace boot disk ID with this new volume's ID,
+        and record snapshot/image ID for later deletion.
+        """
+        sourcevm = self._source_vm()
+        if '/dev/vda' in self.volume_map:
+            mapping = self.volume_map['/dev/vda']
+            volume_id = mapping.source_id
+
+            # Create a snapshot of the root volume
+            logging.info('Creating root device snapshot')
+            root_snapshot = self.conn.create_volume_snapshot(force=True,
+                wait=True, name='rhosp-migration-{}'.format(volume_id),
+                volume_id=volume_id, timeout=DEFAULT_TIMEOUT)
+
+            # Create a new volume from the snapshot
+            logging.info('Creating new volume from root snapshot')
+            root_volume_copy = self.conn.create_volume(wait=True,
+                    name='rhosp-migration-{}'.format(volume_id),
+                    snapshot_id=root_snapshot.id,
+                    size=root_snapshot.size,
+                    timeout=DEFAULT_TIMEOUT)
+
+            # Update the volume map with the new volume ID
+            self.volume_map['/dev/vda'] = mapping._replace(
+                source_id=root_volume_copy.id,
+                snap_id=root_snapshot.id)
+        elif sourcevm.image:
+            logging.info('Image-based instance, creating snapshot...')
+            image = self.conn.compute.create_server_image(server=sourcevm.id,
+                name='rhosp-migration-root-{}'.format(sourcevm.name))
+            for second in range(DEFAULT_TIMEOUT):
+                refreshed_image = self.conn.get_image_by_id(image.id)
+                if refreshed_image.status == 'active':
+                    break
+                time.sleep(1)
+            else:
+                raise RuntimeError('Could not create new image of image-based '
+                    'instance!')
+            volume = self.conn.create_volume(image=image.id, bootable=True,
+                wait=True, timeout=DEFAULT_TIMEOUT, size=image.min_disk,
+                name=image.name)
+            self.volume_map['/dev/vda'] = VolumeMapping(source_dev=None,
+                source_id=volume.id, snap_id=None,
+                image_id=image.id, name=volume.name, size=volume.size,
+                url=None)
+        else:
+            raise RuntimeError('No known boot device found for this instance!')
+
+        for path, mapping in self.volume_map.items():
+            if path == '/dev/vda':
+                continue
+            else: # Detach non-root volumes
+                volume_id = mapping.source_id
+                volume = self.conn.get_volume_by_id(volume_id)
+                logging.info('Detaching %s from %s', volume.id, sourcevm.id)
+                self.conn.detach_volume(server=sourcevm, volume=volume,
+                    wait=True, timeout=DEFAULT_TIMEOUT)
+
+    def _wait_for_volume_dev_path(self, conn, volume, vm, timeout):
+        volume_id = volume.id
+        for second in range(timeout):
+            volume = conn.get_volume_by_id(volume_id)
+            if volume.attachments:
+                attachment = self._get_attachment(volume, vm)
+                if attachment.device.startswith('/dev/'):
+                    return
+            time.sleep(1)
+        raise RuntimeError('Timed out waiting for volume device path!')
+
+    def _attach_volumes(self, conn, host_func, name, ssh_func, update_func,
+            volume_id_func):
+        """
+        Attach all volumes in the volume map to the specified conversion host.
+        Check the list of disks before and after attaching to be absolutely
+        sure the right source data gets copied to the right destination disk.
+        This is here because _attach_destination_volumes and
+        _attach_volumes_to_converter looked almost identical.
+        """
+        logging.info('Attaching volumes to %s wrapper', name)
+        for path, mapping in sorted(self.volume_map.items()):
+            volume_id = volume_id_func(mapping)
+            volume = conn.get_volume_by_id(volume_id)
+            logging.info('Attaching %s to %s conversion host', volume_id, name)
+
+            disks_before = ssh_func(['lsblk', '--noheadings', '--list',
+                '--paths', '--nodeps', '--output NAME'])
+            disks_before = set(disks_before.split())
+            logging.debug('Initial disk list: %s', disks_before)
+
+            conn.attach_volume(volume=volume, wait=True, server=host_func(),
+                timeout=DEFAULT_TIMEOUT)
+            logging.info('Waiting for volume to appear in %s wrapper', name)
+            self._wait_for_volume_dev_path(conn, volume, host_func(),
+                DEFAULT_TIMEOUT)
+
+            disks_after = ssh_func(['lsblk', '--noheadings', '--list',
+                '--paths', '--nodeps', '--output NAME'])
+            disks_after = set(disks_after.split())
+            logging.debug('Updated disk list: %s', disks_after)
+
+            new_disks = disks_after-disks_before
+            volume = conn.get_volume_by_id(volume_id)
+            attachment = self._get_attachment(volume, host_func())
+            dev_path = attachment.device
+            if len(new_disks) == 1:
+                if dev_path in new_disks:
+                    logging.debug('Successfully attached new disk %s, and %s '
+                        'conversion host path agrees with OpenStack.',
+                        dev_path, name)
+                else:
+                    dev_path = new_disks.pop()
+                    logging.debug('Successfully attached new disk %s, but %s '
+                        'conversion host path does not match the result from '
+                        'OpenStack. Using internal device path %s.',
+                        attachment.device, name, dev_path)
+            else:
+                raise RuntimeError('Got unexpected disk list after attaching '
+                    'volume to %s conversion host instance. Failing migration '
+                    'procedure to avoid assigning volumes incorrectly. New '
+                    'disks(s) inside VM: {}, disk provided by OpenStack: '
+                    '{}'.format(name, new_disks, dev_path))
+            self.volume_map[path] = update_func(mapping, dev_path)
+
+    def _use_lock(lock_file):
+        """ Boilerplate for functions that need to take a lock. """
+        def _decorate_lock(function):
+            def wait_for_lock(self):
+                with open(lock_file, 'wb+') as lock:
+                    for second in range(DEFAULT_TIMEOUT):
+                        try:
+                            logging.info('Waiting for lock %s...', lock_file)
+                            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                            break
+                        except OSError as error:
+                            logging.info('Another conversion has the lock.')
+                            time.sleep(1)
+                    else:
+                        raise RuntimeError('Unable to acquire lock %s!',
+                            lock_file)
+                    try:
+                        function(self)
+                    finally:
+                        fcntl.flock(lock, fcntl.LOCK_UN)
+            return wait_for_lock
+        return _decorate_lock
+
+    # Lock this part to have a better chance of the OpenStack device path
+    # matching the device path seen inside the conversion host.
+    @_use_lock(ATTACH_LOCK_FILE_SOURCE)
+    def _attach_volumes_to_converter(self):
+        """
+        Attach all the source volumes to the conversion host. Volume mapping
+        step 3: fill in the volume's device path on the source conversion host.
+        """
+        def update_source(volume_mapping, dev_path):
+            return volume_mapping._replace(source_dev=dev_path)
+        def volume_id(volume_mapping):
+            return volume_mapping.source_id
+        self._attach_volumes(self.conn, self._converter, 'source',
+            self._converter_out, update_source, volume_id)
+
+    def _export_volumes_from_converter(self):
+        """
+        SSH to source conversion host and start an NBD export. Start the UCI
+        with /dev/vdb, /dev/vdc, etc. attached, then pass JSON input to request
+        nbdkit exports from the V2V wrapper. Volume mapping step 4: fill in the
+        URL to the volume's matching NBD export.
+        """
+        logging.info('Exporting volumes from source conversion host...')
+
+        # Create a temporary directory on source conversion host
+        self.tmpdir = self._converter_out(['mktemp', '-d', '-t', 'v2v-XXXXXX'])
+        logging.info('Source conversion host temp dir: %s', self.tmpdir)
+
+        # Choose NBD ports for inside the container
+        port = 10809
+        port_map = {} # Map device path to port number, for export_nbd
+        reverse_port_map = {} # Map port number to device path, for forwarding
+        nbd_ports = [] # podman arguments for NBD ports
+        device_list = [] # podman arguments for block devices
+        for path, mapping in self.volume_map.items():
+            volume_id = mapping.source_id
+            dev_path = mapping.source_dev
+            uci_dev_path = mapping.source_dev+'-v2v'
+            logging.info('Exporting %s from volume %s', dev_path, volume_id)
+            nbd_ports.extend(['-p', '{0}'.format(port)])
+            device_list.extend(['--device', dev_path+':'+uci_dev_path])
+            reverse_port_map[port] = path
+            port_map[uci_dev_path] = port
+            port += 1
+
+        # Copy the port map as input to the source conversion host wrapper
+        self._converter_val(['mkdir', '-p', self.tmpdir+'/lib'])
+        self._converter_val(['mkdir', '-p', self.tmpdir+'/log'])
+        self._converter_val(['mkdir', '-p', self.tmpdir+'/input'])
+        ports = json.dumps({'nbd_export_only': port_map})
+        nbd_conversion = '/tmp/nbd_conversion.json'
+        with open(nbd_conversion, 'w+') as conversion:
+            conversion.write(ports)
+        self._converter_scp(nbd_conversion,
+            self.tmpdir+'/input/conversion.json')
+
+        # Run UCI on source conversion host. Create a temporary directory to
+        # use as the UCI's /data directory so more than one can run at a time.
+        ssh_args = ['sudo', 'podman', 'run', '--detach']
+        ssh_args.extend(['--volume', '/var/tmp:/var/tmp:z'])
+        ssh_args.extend(['--volume', '/var/lock:/var/lock:z'])
+        ssh_args.extend(['--volume', self.tmpdir+':/data:z'])
+        ssh_args.extend(['--volume', self.tmpdir+'/lib:/var/lib/uci:z'])
+        ssh_args.extend(['--volume', self.tmpdir+'/log:/var/log/uci:z'])
+        ssh_args.extend(['--volume',
+            '/opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib'])
+        ssh_args.extend(nbd_ports)
+        ssh_args.extend(device_list)
+        ssh_args.extend(['v2v-conversion-host'])
+        self.uci_id = self._converter_out(ssh_args)
+        logging.debug('Source UCI container ID: %s', self.uci_id)
+
+        # Find the ports chosen by podman and forward them
+        ssh_args = ['sudo', 'podman', 'port', self.uci_id]
+        out = self._converter_out(ssh_args)
+        forward_ports = ['-N', '-T']
+        for line in out.split('\n'): # Format: 10809/tcp -> 0.0.0.0:33437
+            logging.debug('Forwarding port from podman: %s', line)
+            internal_port, _, _ = line.partition('/')
+            _, _, external_port = line.rpartition(':')
+            port = int(internal_port)
+            path = reverse_port_map[port]
+            # The internal_port in the source conversion container is forwarded
+            # to external_port on the source conversion host, and then we need
+            # any local port on the destination conversion container to forward
+            # over SSH to that external_port. For simplicity, just choose the
+            # same as internal_port, so both source and destination containers
+            # use the same ports for the same NBD volumes. This is worth
+            # explaining in detail because otherwise the following arguments
+            # may look backwards at first glance.
+            forward_ports.extend(['-L', '{}:localhost:{}'.format(internal_port,
+                external_port)])
+            mapping = self.volume_map[path]
+            url = 'nbd://localhost:'+internal_port
+            self.volume_map[path] = mapping._replace(url=url)
+            logging.info('Volume map so far: %s', self.volume_map)
+
+        # Get SSH to forward the NBD ports to localhost
+        self.forwarding_process = self._converter_sub(forward_ports)
+
+        # Make sure export worked by checking the exports. The conversion
+        # host on the source should create an 'nbdready' file after it has
+        # started all the nbdkit processes, and after that qemu-img info
+        # should be able to read them.
+        logging.info('Waiting for NBD exports from source container...')
+        sentinel = os.path.join(self.tmpdir, NBD_READY_SENTINEL)
+        for second in range(DEFAULT_TIMEOUT):
+            if self._converter_val(['test', '-f', sentinel]) == 0:
+                break
+            time.sleep(1)
+        else:
+            raise RuntimeError('Timed out waiting for NBD export!')
+        for path, mapping in self.volume_map.items():
+            cmd = ['qemu-img', 'info', mapping.url]
+            image_info = subprocess.check_output(cmd)
+            logging.info('qemu-img info for %s: %s', path, image_info)
+
+    def _converter_close_exports(self):
+        """
+        SSH to source conversion host and close the NBD export. Currently this
+        pretty much amounts to just stopping the container.
+        """
+        logging.info('Stopping export from source conversion host...')
+        try:
+            out = self._converter_out(['sudo', 'podman', 'stop', self.uci_id])
+            logging.info('Closed NBD export with result: %s', out)
+
+            # Copy logs from temporary directory locally, and clean up source
+            if self.tmpdir:
+                os.mkdir(SOURCE_LOGS_DIR)
+                self._converter_scp_from(self.tmpdir+'/*', SOURCE_LOGS_DIR,
+                    recursive=True)
+                self._converter_out(['rm', '-rf', self.tmpdir])
+
+            self.forwarding_process.terminate()
+        except Exception as error:
+            pass
+
+
+    def _volume_still_attached(self, volume, vm):
+        """ Check if a volume is still attached to a VM. """
+        for attachment in volume.attachments:
+            if attachment.server_id == vm.id:
+                return True
+        return False
+
+    @_use_lock(ATTACH_LOCK_FILE_SOURCE)
+    def _detach_volumes_from_converter(self):
+        """ Detach volumes from conversion host. """
+        converter = self._converter()
+        for path, mapping in self.volume_map.items():
+            volume = self.conn.get_volume_by_id(mapping.source_id)
+            logging.info('Inspecting volume %s', volume.id)
+            if mapping.source_dev is None:
+                logging.info('Volume is not attached to conversion host, '
+                    'skipping detach.')
+                continue
+            self.conn.detach_volume(server=converter, wait=True,
+                timeout=DEFAULT_TIMEOUT, volume=volume)
+            for second in range(DEFAULT_TIMEOUT):
+                converter = self._converter()
+                volume = self.conn.get_volume_by_id(mapping.source_id)
+                if not self._volume_still_attached(volume, converter):
+                    break
+                time.sleep(1)
+            else:
+                raise RuntimeError('Timed out waiting to detach volumes from '
+                    'source conversion host!')
+
+    def _attach_data_volumes_to_source(self):
+        """ Clean up the copy of the root volume and reattach data volumes. """
+        logging.info('Re-attaching volumes to source VM...')
+        for path, mapping in sorted(self.volume_map.items()):
+            if path == '/dev/vda':
+                # Delete the temporary copy of the source root disk
+                logging.info('Removing copy of root volume')
+                self.conn.delete_volume(name_or_id=mapping.source_id,
+                    wait=True, timeout=DEFAULT_TIMEOUT)
+
+                # Remove the root volume snapshot
+                if mapping.snap_id:
+                    logging.info('Deleting temporary root device snapshot')
+                    self.conn.delete_volume_snapshot(timeout=DEFAULT_TIMEOUT,
+                        wait=True, name_or_id=mapping.snap_id)
+
+                # Remove root image copy, for image-launched instances
+                if mapping.image_id:
+                    logging.info('Deleting temporary root device image')
+                    self.conn.delete_image(timeout=DEFAULT_TIMEOUT,
+                        wait=True, name_or_id=mapping.image_id)
+            else:
+                # Attach data volumes back to source VM
+                volume = self.conn.get_volume_by_id(mapping.source_id)
+                sourcevm = self._source_vm()
+                try:
+                    attachment = self._get_attachment(volume, sourcevm)
+                except RuntimeError:
+                    logging.info('Attaching %s back to source VM', volume.id)
+                    self.conn.attach_volume(volume=volume, wait=True,
+                        server=sourcevm, timeout=DEFAULT_TIMEOUT)
+                else:
+                    logging.info('Volume %s is already attached to source VM',
+                        volume.id)
+                    continue

--- a/wrapper/source_hosts.py
+++ b/wrapper/source_hosts.py
@@ -23,7 +23,7 @@ import subprocess
 import time
 from collections import namedtuple
 
-from .common import RUN_DIR, LOG_DIR, VDDK_LIBDIR
+from .common import RUN_DIR, LOG_DIR, VDDK_LIBDIR, disable_interrupt
 from .hosts import OpenstackHost
 from .state import STATE, Disk
 from .pre_copy import PreCopy
@@ -192,6 +192,7 @@ class OpenStackSourceHost(_BaseSourceHost):
         self._attach_volumes_to_converter()
         self._export_volumes_from_converter()
 
+    @disable_interrupt
     def close_exports(self):
         """ Put the source VM's volumes back where they were. """
         self._converter_close_exports()

--- a/wrapper/source_hosts.py
+++ b/wrapper/source_hosts.py
@@ -23,7 +23,7 @@ import subprocess
 import time
 from collections import namedtuple
 
-from .common import VDDK_LIBDIR
+from .common import RUN_DIR, LOG_DIR, VDDK_LIBDIR
 from .hosts import OpenstackHost
 from .state import STATE, Disk
 from .pre_copy import PreCopy
@@ -539,8 +539,8 @@ class OpenStackSourceHost(_BaseSourceHost):
         ssh_args.extend(['--volume', '/var/tmp:/var/tmp:z'])
         ssh_args.extend(['--volume', '/var/lock:/var/lock:z'])
         ssh_args.extend(['--volume', self.tmpdir+':/data:z'])
-        ssh_args.extend(['--volume', self.tmpdir+'/lib:/var/lib/uci:z'])
-        ssh_args.extend(['--volume', self.tmpdir+'/log:/var/log/uci:z'])
+        ssh_args.extend(['--volume', self.tmpdir+'/lib:'+RUN_DIR+':z'])
+        ssh_args.extend(['--volume', self.tmpdir+'/log:'+LOG_DIR+':z'])
         ssh_args.extend(['--volume', '{0}:{0}'.format(VDDK_LIBDIR)])
         ssh_args.extend(nbd_ports)
         ssh_args.extend(device_list)

--- a/wrapper/source_hosts.py
+++ b/wrapper/source_hosts.py
@@ -181,7 +181,8 @@ class OpenStackSourceHost(_BaseSourceHost):
             self.source_disks = data['source_disks']
 
         # Allow UCI container ID (or name) to be passed in input JSON
-        self.uci_container = data.get('uci_container', 'v2v-conversion-host')
+        self.uci_container = data.get('uci_container_image',
+                                      'v2v-conversion-host')
 
     def prepare_exports(self):
         """ Attach the source VM's volumes to the source conversion host. """

--- a/wrapper/source_hosts.py
+++ b/wrapper/source_hosts.py
@@ -139,13 +139,10 @@ class OpenStackSourceHost(_BaseSourceHost):
         except ImportError:
             raise RuntimeError('OpenStack SDK is not installed on this '
                                'conversion host!')
-        osp_arg_list = ['os-auth_url', 'os-username', 'os-password',
-                        'os-project_name', 'os-project_domain_name',
-                        'os-user_domain_name']
 
         # Create a connection to the source cloud
         osp_env = data['osp_source_environment']
-        osp_args = {arg[3:].lower(): osp_env[arg] for arg in osp_arg_list}
+        osp_args = {arg[3:].lower(): osp_env[arg] for arg in osp_env}
         osp_args['verify'] = not data.get('insecure_connection', False)
         self.source_converter = data['osp_source_conversion_vm_id']
         self.source_instance = data['osp_source_vm_id']
@@ -153,7 +150,7 @@ class OpenStackSourceHost(_BaseSourceHost):
 
         # Create a connection to the destination cloud
         osp_env = data['osp_environment']
-        osp_args = {arg[3:].lower(): osp_env[arg] for arg in osp_arg_list}
+        osp_args = {arg[3:].lower(): osp_env[arg] for arg in osp_env}
         osp_args['verify'] = not data.get('insecure_connection', False)
         self.dest_converter = data['osp_server_id']
         self.dest_conn = openstack.connect(**osp_args)

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -381,7 +381,7 @@ def main():
         if not STATE.failed:
             if source_host and source_host.avoid_wrapper(host):
                 source_host.transfer_exports(host)
-            else: # TODO: allow connecting source hosts to virt-v2v
+            else:  # TODO: allow connecting source hosts to virt-v2v
                 wrapper(host, data, virt_v2v_caps, agent_sock)
         if source_host:
             source_host.close_exports()

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -379,7 +379,10 @@ def main():
             host.prepare_disks(data)
             STATE.pre_copy.copy_disks(data['vmware_password_file'])
         if not STATE.failed:
-            wrapper(host, data, virt_v2v_caps, agent_sock)
+            if source_host and source_host.avoid_wrapper(host):
+                source_host.transfer_exports(host)
+            else: # TODO: allow connecting source hosts to virt-v2v
+                wrapper(host, data, virt_v2v_caps, agent_sock)
         if source_host:
             source_host.close_exports()
         if agent_pid is not None:

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -32,6 +32,8 @@ from .common import error, hard_error, log_command_safe, write_password
 from .common import setup_signals, disable_interrupt
 from .common import RUN_DIR, LOG_DIR, VDDK_LIBDIR, VIRT_V2V
 from .hosts import detect_host
+from .source_hosts import detect_source_host
+from .exports import export_nbd
 from .log_parser import log_parser
 from .checks import CHECKS
 from .pre_copy import PreCopy
@@ -252,6 +254,9 @@ def main():
 
     # Read and parse input -- hopefully this should be safe to do as root
     data = json.load(sys.stdin)
+    if 'nbd_export_only' in data:
+        export_nbd(data['nbd_export_only'])
+        sys.exit(0)
     host = detect_host(data)
 
     # The logging is delayed until we now which user runs the wrapper.
@@ -360,11 +365,23 @@ def main():
                 data, host.get_uid(), host.get_gid())
             if agent_pid is None:
                 raise RuntimeError('Failed to start ssh-agent')
+        source_host = detect_source_host(data, agent_sock)
+        if source_host:
+            try:
+                source_host.prepare_exports()
+            except Exception as e:
+                error_name = e.args[0] if e.args else "Wrapper failure"
+                error(error_name, 'Failed to prepare NBD exports!',
+                      exception=True)
+                source_host.close_exports()
+                STATE.failed = True
         if STATE.pre_copy:
             host.prepare_disks(data)
             STATE.pre_copy.copy_disks(data['vmware_password_file'])
         if not STATE.failed:
             wrapper(host, data, virt_v2v_caps, agent_sock)
+        if source_host:
+            source_host.close_exports()
         if agent_pid is not None:
             os.kill(agent_pid, signal.SIGTERM)
 


### PR DESCRIPTION
Here is an attempt at direct migrations from one OpenStack cloud to another.

It works using two conversion hosts, one in an instance on the source OpenStack cloud and one in an instance on the destination OpenStack cloud. Volumes are detached from their source instances and attached to the source conversion host, and exported from inside the source conversion host with nbdkit. The destination conversion host performs all the OpenStack API manipulations and converts the exports to new destination volumes attached to itself.

After the transfer is complete, the wrapper's existing OpenStack host support starts a new instance with the newly created volumes.