### PR TITLE
Increase disks operations timeout

### DIFF
--- a/wrapper/hosts.py
+++ b/wrapper/hosts.py
@@ -23,7 +23,7 @@ from .state import STATE
 from .osp_wrapper import osp_wrapper_create
 
 
-TIMEOUT = 300
+TIMEOUT = 600
 
 
 # NOTE: This in reality binds output method (rhv-upload, openstack) to the


### PR DESCRIPTION
It appears that the disk creation cant take more than the allowed 5 minutes under heavy load. 
Doubling to 10 minutes should cover most cases.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1817341