### PR TITLE
Various fixes for warm migration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 ovirt-engine-sdk-python
 pycurl
-six
 yamllint
 tox
 flake8

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
     },
     install_requires=[
         'pycurl',
-        'six',
         'libvirt-python',
         'pyvmomi',
         'packaging',

--- a/wrapper/common.py
+++ b/wrapper/common.py
@@ -76,11 +76,6 @@ def error(short_message, *args, **kwargs):
 def hard_error(msg):
     """
     Function to produce an error and terminate the wrapper.
-
-    WARNING: This can be used only at the early initialization stage! Do NOT
-    use this once the password files are written or there are any other
-    temporary data that should be removed at exit. This function uses
-    sys.exit() which overcomes the code responsible for removing the files.
     """
     logging.error(msg)
     sys.stderr.write(msg)
@@ -90,6 +85,8 @@ def hard_error(msg):
             'message': msg,
             'type': 'error'
         }
+        STATE.failed = True
+        STATE.finished = True
         STATE.write()
     sys.exit(1)
 

--- a/wrapper/hosts.py
+++ b/wrapper/hosts.py
@@ -6,7 +6,6 @@ import math
 import os
 import pycurl
 import re
-import six
 import stat
 import subprocess
 import time
@@ -561,7 +560,7 @@ class OpenstackHost(_BaseHost):
             '-oo', 'guest-id=%s' % data['osp_guest_id'],
             ])
         # Convert to arguments of the form os-something
-        for k, v in six.iteritems(data['osp_environment']):
+        for k, v in data['osp_environment'].items():
             v2v_args.extend([
                 '-oo',
                 '%s=%s' % (k.lower().replace('_', '-'), v)])
@@ -651,7 +650,7 @@ class OpenstackHost(_BaseHost):
         if data.get('insecure_connection', False):
             command.append('--insecure')
         # Convert to arguments of the form os-something
-        for k, v in six.iteritems(data['osp_environment']):
+        for k, v in data['osp_environment'].items():
             command.append('--%s=%s' % (k.lower().replace('_', '-'), v))
         if destination:
             # It doesn't matter if there already is --os-project-name or

--- a/wrapper/log_parser.py
+++ b/wrapper/log_parser.py
@@ -34,8 +34,6 @@ class OutputParser(object):
         br' \'?virt_v2v_disk_index=(?P<volume>[0-9]+)/[0-9]+.*'
         br' \'?(?P<uuid>[a-fA-F0-9-]*)\'?$')
     SSH_VMX_GUEST_NAME = re.compile(br'^displayName = "(.*)"$')
-    OVERLAY_PATH_RE = re.compile(
-        br'virt-v2v: Overlay saved as (?P<path>/.*\.qcow2) ')
 
     def __init__(self, duplicate=False):
         # Wait for the log files to appear
@@ -49,7 +47,6 @@ class OutputParser(object):
         self._current_disk = None
         self._current_path = None
         self._duplicate = duplicate
-        self._current_overlay_disk = 0
 
     def __del__(self):
         self._log.close()
@@ -85,18 +82,6 @@ class OutputParser(object):
             logging.info('Created VM with id=%s', vm_id)
 
         if STATE.pre_copy:
-            # Ovelays to commit in two_phase mode
-            m = self.OVERLAY_PATH_RE.match(line)
-            if m is not None:
-                path = m.group('path').decode('utf-8')
-                disks = STATE.pre_copy.disks
-                if self._current_overlay_disk >= len(disks):
-                    error('Disk list mismatch when getting overlay data')
-                disks[self._current_overlay_disk].overlay = path
-                logging.debug('Attaching overlay path "%s" to disk "%d"',
-                              path, self._current_overlay_disk)
-                self._current_overlay_disk += 1
-
             # There is nothing else to parse for two-phase conversion
             return
 

--- a/wrapper/pre_copy.py
+++ b/wrapper/pre_copy.py
@@ -994,6 +994,8 @@ class PreCopy(StateObject):
     def commit_overlays(self):
         "Commit all overlays to local disks."
 
+        STATE.status = 'Finishing (committing overlays)'
+
         ndisks = len(self.disks)
         cmd_templ = ['qemu-img', 'commit', '-p']
         for i, disk in enumerate(self.disks):

--- a/wrapper/pre_copy.py
+++ b/wrapper/pre_copy.py
@@ -33,7 +33,7 @@ MAX_PREAD_LEN = 23 << 20        # 23MB (24M requests fail in vddk)
 BlockStatusData = namedtuple('BlockStatusData', ['offset', 'length', 'flags'])
 
 
-def get_block_status(nbd_handle, extents):
+def _get_block_status(nbd_handle, extents):
     blocks = []
 
     def update_blocks(metacontext, offset, extents, err):
@@ -472,7 +472,7 @@ class _PreCopyDisk(StateObject):
         self.status = 'Copying (getting block stats)'
         STATE.write()
 
-        blocks = get_block_status(nbd_handle, self.extents)
+        blocks = _get_block_status(nbd_handle, self.extents)
         data_blocks = [x for x in blocks if not x.flags & self.nbd.STATE_HOLE]
 
         logging.debug('Block status filtered down to %d data blocks',

--- a/wrapper/pre_copy.py
+++ b/wrapper/pre_copy.py
@@ -6,7 +6,6 @@ import fcntl
 import libvirt
 import logging
 import re
-import six
 import stat
 import subprocess
 import tempfile
@@ -670,7 +669,7 @@ class PreCopy(StateObject):
             disk_data.fixed = True
 
         # Check that all paths were changed
-        for k, v in six.iteritems(disk_map):
+        for k, v in disk_map.items():
             if not v.fixed:
                 raise RuntimeError('Disk path "%s" was '
                                    'not fixed in the domxml' % k)

--- a/wrapper/pre_copy.py
+++ b/wrapper/pre_copy.py
@@ -521,6 +521,7 @@ class _PreCopyDisk(StateObject):
         if len(data_blocks) == 0:
             logging.debug('No extents have allocated data for disk: %s',
                           self.logname)
+            self.status = 'Copied'
             return
 
         copy.status = 'Copying'

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -48,6 +48,14 @@ LOG_LEVEL = logging.DEBUG
 #
 
 def prepare_command(data, v2v_caps, agent_sock=None):
+    # Prepare environment
+    v2v_env = os.environ.copy()
+    v2v_env['LANG'] = 'C'
+    logging.debug('Using direct backend. Hack, hack...')
+    v2v_env['LIBGUESTFS_BACKEND'] = 'direct'
+    if agent_sock is not None:
+        v2v_env['SSH_AUTH_SOCK'] = agent_sock
+
     v2v_args = [
         '-v', '-x',
         '--root', 'first',
@@ -55,13 +63,7 @@ def prepare_command(data, v2v_caps, agent_sock=None):
     ]
 
     if STATE.pre_copy:
-        v2v_args.extend([
-            STATE.pre_copy.get_xml(),
-            '-i', 'libvirtxml',
-            # TODO: Remove later when v2v has support for direct commit
-            '--debug-overlays',
-            '--no-copy',
-        ])
+        STATE.pre_copy.prepare_command(v2v_env, v2v_args)
     else:
         if data['transport_method'] == 'vddk':
             v2v_args.extend([
@@ -99,14 +101,6 @@ def prepare_command(data, v2v_caps, agent_sock=None):
                     luks_key['filename']
                 )
             ])
-
-    # Prepare environment
-    v2v_env = os.environ.copy()
-    v2v_env['LANG'] = 'C'
-    logging.debug('Using direct backend. Hack, hack...')
-    v2v_env['LIBGUESTFS_BACKEND'] = 'direct'
-    if agent_sock is not None:
-        v2v_env['SSH_AUTH_SOCK'] = agent_sock
 
     return (v2v_args, v2v_env)
 

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -112,7 +112,8 @@ def wrapper(host, data, v2v_caps, agent_sock=None):
     v2v_args, v2v_env = host.prepare_command(
         data, v2v_args, v2v_env, v2v_caps)
 
-    logging.info('Starting virt-v2v:')
+    STATE.status = 'Starting virt-v2v'
+    logging.info(STATE.status)
     log_command_safe(v2v_args, v2v_env)
 
     runner = SubprocessRunner(v2v_args, v2v_env, STATE.v2v_log)

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -29,6 +29,7 @@ import time
 
 from .state import STATE, Disk
 from .common import error, hard_error, log_command_safe, write_password
+from .common import setup_signals, disable_interrupt
 from .common import RUN_DIR, LOG_DIR, VDDK_LIBDIR
 from .hosts import detect_host
 from .log_parser import log_parser
@@ -280,6 +281,7 @@ def main():
             hard_error("This output does not support two-phase conversion")
         STATE.pre_copy.init_disk_data()
 
+    setup_signals()
     try:
         #
         # NOTE: don't use hard_error() beyond this point!
@@ -421,6 +423,7 @@ def validate_data(host, data):
     STATE.pre_copy = PreCopy(data)
 
 
+@disable_interrupt
 def finish(host, data):
     if STATE.failed:
         # Perform cleanup after failed conversion

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -431,16 +431,19 @@ def finish(host, data):
         logging.debug('Cleanup phase')
         # Need to clean up as much as possible, even if only one tiny clean up
         # function fails
-        try:
-            host.handle_cleanup(data)
-        except Exception:
-            logging.exception("Got exception while cleaning up data")
 
+        # Clean-up pre-copy stuff first so that host-related resources are not
+        # used any more
         if STATE.pre_copy:
             try:
                 STATE.pre_copy.cleanup()
             except Exception:
                 logging.exception("Got exception while cleaning up data")
+
+        try:
+            host.handle_cleanup(data)
+        except Exception:
+            logging.exception("Got exception while cleaning up data")
 
     # Remove password files
     logging.info('Removing password files')


### PR DESCRIPTION
This series introduces three main things:

1) When creating a snapshot fails, try again.
1) Do not parse overlay file names from the log output.
1) When copy iteration fails, retry during the next iteration (this Fixes #27 ).

Missing things so that this is not a draft any more:

- [x] Handle signals to properly clean up when killed by ManageIQ (cancellation)
- [x] Do lot more testing

And maybe also (unless we decide otherwise):

- [ ] Have at least some documentation about basic parts of the state file
- [ ] Error out after specified number of copy iterations failed (for now it continues indefinitely)
- [ ] Error out when the initial copy iteration fails (for now it just retries that next time)