### PR TITLE
Fetch disk id and name using disk object 

### DIFF
--- a/kubevirt-vmware/pkg/controller/ovirtprovider/client.go
+++ b/kubevirt-vmware/pkg/controller/ovirtprovider/client.go
@@ -214,12 +214,6 @@ func (c *Client) getRaw(sourceVM *ovirtsdk.Vm) (string, error) {
 	}
 	for _, diskAttachment := range diskAttachments.(*ovirtsdk.DiskAttachmentSlice).Slice() {
 		disk := &disk{}
-		if id, ok := diskAttachment.Id(); ok {
-			disk.ID = id
-		}
-		if name, ok := diskAttachment.Name(); ok {
-			disk.Name = name
-		}
 		if bootable, ok := diskAttachment.Bootable(); ok {
 			disk.Bootable = bootable
 		}
@@ -233,6 +227,12 @@ func (c *Client) getRaw(sourceVM *ovirtsdk.Vm) (string, error) {
 		}
 		if size, ok := vmDisk.(*ovirtsdk.Disk).ProvisionedSize(); ok {
 			disk.Size = size
+		}
+		if id, ok := vmDisk.(*ovirtsdk.Disk).Id(); ok {
+			disk.ID = id
+		}
+		if name, ok := vmDisk.(*ovirtsdk.Disk).Alias(); ok {
+			disk.Name = name
 		}
 		sdLink, _ := vmDisk.(*ovirtsdk.Disk).StorageDomains()
 		sd, err := c.conn.FollowLink(sdLink.Slice()[0])


### PR DESCRIPTION
This PR fixes an issue with empty disk name. We should use alias from `disk` object not `diskattachement` name to provide this information.

There is similar situation with disk id. We should get this value from `disk` object not `diskattachement`.