### PR TITLE
pre_copy: make sure overlay files are in /var/tmp

### DIFF
--- a/wrapper/pre_copy.py
+++ b/wrapper/pre_copy.py
@@ -653,7 +653,9 @@ class PreCopy(StateObject):
         import nbd
         self.nbd = nbd
 
-        self._tmp_dir = tempfile.TemporaryDirectory(prefix='v2v-')
+        self._tmp_dir = tempfile.TemporaryDirectory(
+                prefix='v2v-',
+                dir=os.environ.get('LIBGUESTFS_CACHEDIR', '/var/tmp'))
 
         self.disks = None
 


### PR DESCRIPTION
... or in location of LIBGUESTFS_CACHEDIR if that one is set.

Signed-off-by: Tomáš Golembiovský <tgolembi@redhat.com>