### PR TITLE
wrapper: Always use LIBGUESTFS_CACHEDIR

### DIFF
--- a/docs/Virt-v2v-wrapper.md
+++ b/docs/Virt-v2v-wrapper.md
@@ -27,6 +27,18 @@ The expected usage is as follows:
 5)  *finalization*: when virt-v2v terminates wrapper updates the state file
     one last time and exits
 
+## Temporary files
+
+Any temporary files (even from any other tools spawned by the wrapper) are
+stored under a specific path and cleaned up after exit.  The path is
+configurable as it is determined based on environment variables in this manner:
+
+* `V2V_WRAPPER_TMPDIR` or, if if the variable is not set, then
+
+* `TMPDIR` to allow for a sane system default or
+
+* the literal path `/var/tmp` as a fallback if none of the above exist in the
+  environment
 
 ## Input Data
 

--- a/wrapper/common.py
+++ b/wrapper/common.py
@@ -116,7 +116,7 @@ def log_command_safe(args, env, log=None):
 
 
 def write_password(password, host):
-    pfile = tempfile.mkstemp(suffix='.v2v')
+    pfile = tempfile.mkstemp(suffix='.v2v', dir=STATE.tmp_dir())
     STATE.internal['password_files'].append(pfile[1])
     os.fchown(pfile[0], host.get_uid(), host.get_gid())
     os.write(pfile[0], bytes(password.encode('utf-8')))

--- a/wrapper/common.py
+++ b/wrapper/common.py
@@ -4,7 +4,6 @@ import logging
 import os
 import re
 import signal
-import stat
 import subprocess
 import sys
 import tempfile
@@ -123,24 +122,6 @@ def write_password(password, host):
     os.write(pfile[0], bytes(password.encode('utf-8')))
     os.close(pfile[0])
     return pfile[1]
-
-
-def add_perms_to_file(path, modes, uid=-1, gid=-1):
-    cur_mode = stat.S_IMODE(os.stat(path).st_mode)
-    new_mode = cur_mode | modes
-
-    if uid != -1 or gid != -1:
-        logging.debug('Changing uid:gid of "%s" to %s:%s',
-                      path, uid, gid)
-        os.chown(path, uid, gid)
-
-    logging.debug('Changing permissions on "%s" from 0%o to 0%o',
-                  path, cur_mode, new_mode)
-    os.chmod(path, new_mode)
-
-
-def nbd_uri_from_unix_socket(sock_path):
-    return 'nbd+unix:///?socket=%s' % sock_path
 
 
 def setup_signals():

--- a/wrapper/hosts.py
+++ b/wrapper/hosts.py
@@ -547,7 +547,8 @@ class OpenstackHost(_BaseHost):
     def prepare_command(self, data, v2v_args, v2v_env, v2v_caps):
         """ Prepare virt-v2v command parts that are method dependent """
         if data['two_phase']:
-            self._tmp_dir = tempfile.TemporaryDirectory(prefix='v2v-osp-')
+            self._tmp_dir = tempfile.TemporaryDirectory(prefix='v2v-osp-',
+                                                        dir=STATE.tmp_dir())
             osp_wrapper_create(self._tmp_dir.name,
                                'openstack',
                                [x.id for x in self._created_disks],

--- a/wrapper/hosts.py
+++ b/wrapper/hosts.py
@@ -17,8 +17,8 @@ from contextlib import contextmanager
 from io import BytesIO
 from urllib.parse import urlparse
 
-from .common import error, hard_error, log_command_safe, add_perms_to_file
-from .common import disable_interrupt
+from .common import error, hard_error, log_command_safe, disable_interrupt
+from .utils import add_perms_to_file
 from .state import STATE
 from .osp_wrapper import osp_wrapper_create
 

--- a/wrapper/osp_wrapper.py
+++ b/wrapper/osp_wrapper.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import stat
 
-from wrapper.common import add_perms_to_file
+from wrapper.utils import add_perms_to_file
 
 _SCRIPT = r'''#!/bin/bash
 

--- a/wrapper/pre_copy.py
+++ b/wrapper/pre_copy.py
@@ -17,8 +17,8 @@ from packaging import version
 from urllib.parse import urlparse, unquote, quote, parse_qs
 
 from .state import STATE, StateObject
-from .common import RUN_DIR, VDDK_LIBDIR, VDDK_LIBRARY_PATH
-from .common import add_perms_to_file, error, nbd_uri_from_unix_socket
+from .common import RUN_DIR, VDDK_LIBDIR, VDDK_LIBRARY_PATH, error
+from .utils import add_perms_to_file, nbd_uri_from_unix_socket
 
 
 _TIMEOUT = 10

--- a/wrapper/state.py
+++ b/wrapper/state.py
@@ -120,5 +120,11 @@ class _State(StateObject):
             json.dump(self, f, cls=_StateEncoder)
             os.rename(tmp_state[1], self.state_file)
 
+    def finish(self):
+        if self.failed is None:
+            self.failed = False
+        self.finished = True
+        self.write()
+
 
 STATE = _State()

--- a/wrapper/tests/test_pre_copy.py
+++ b/wrapper/tests/test_pre_copy.py
@@ -1,6 +1,6 @@
 import unittest
 from wrapper.pre_copy import _VMWare, PreCopy
-from wrapper.pre_copy import _get_overlay_path, _get_index_string
+from wrapper.pre_copy import _get_index_string
 
 
 class TestPreCopy(unittest.TestCase):
@@ -176,15 +176,3 @@ class TestPreCopy(unittest.TestCase):
         # function and against linux kernel code up to 'jjjj'.
         for i in range(1024):
             str_idx_eq(i)
-
-    def test_get_disk_path(self):
-        """ Check that overlay paths are constructed properly. """
-
-        self.assertEqual(_get_overlay_path('/some/temp/path', 'MyVM', 0),
-                         '/some/temp/path/MyVM-sda.qcow2')
-        self.assertEqual(_get_overlay_path('/other/path', 'vmName', 27),
-                         '/other/path/vmName-sdab.qcow2')
-        self.assertEqual(_get_overlay_path('/other/path', 'vmName', 51),
-                         '/other/path/vmName-sdaz.qcow2')
-        self.assertEqual(_get_overlay_path('/an/other/one', 'test', 18277),
-                         '/an/other/one/test-sdzzz.qcow2')

--- a/wrapper/utils.py
+++ b/wrapper/utils.py
@@ -1,0 +1,28 @@
+"""
+Common self-contained utilities
+
+This file does not depend on any other file, not even state.py and cannot
+therefore introduce circular dependencies
+"""
+
+import os
+import stat
+import logging
+
+
+def add_perms_to_file(path, modes, uid=-1, gid=-1):
+    cur_mode = stat.S_IMODE(os.stat(path).st_mode)
+    new_mode = cur_mode | modes
+
+    if uid != -1 or gid != -1:
+        logging.debug('Changing uid:gid of "%s" to %s:%s',
+                      path, uid, gid)
+        os.chown(path, uid, gid)
+
+    logging.debug('Changing permissions on "%s" from 0%o to 0%o',
+                  path, cur_mode, new_mode)
+    os.chmod(path, new_mode)
+
+
+def nbd_uri_from_unix_socket(sock_path):
+    return 'nbd+unix:///?socket=%s' % sock_path

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -475,10 +475,7 @@ def finish(host, data):
                   'Error removing password file: %s' % f,
                   exception=True)
 
-    if STATE.failed is None:
-        STATE.failed = False
-    STATE.finished = True
-    STATE.write()
+    STATE.finish()
 
 
 # }}}

--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -55,6 +55,7 @@ def prepare_command(data, v2v_caps, agent_sock=None):
     v2v_env['LANG'] = 'C'
     logging.debug('Using direct backend. Hack, hack...')
     v2v_env['LIBGUESTFS_BACKEND'] = 'direct'
+    v2v_env['LIBGUESTFS_CACHEDIR'] = STATE.tmp_dir()
     if agent_sock is not None:
         v2v_env['SSH_AUTH_SOCK'] = agent_sock
 
@@ -466,6 +467,10 @@ def finish(host, data):
             logging.exception("Got exception while cleaning up data")
 
     # Remove password files
+    #
+    # These will eventually be removed in STATE.finish(), but until that is
+    # tested (and maybe more stuff is moved to the STATE object, which might
+    # become the WrapperApp object at some point) this stays here to be sure.
     logging.info('Removing password files')
     for f in STATE.internal['password_files']:
         try:


### PR DESCRIPTION
Let's not leave it to luck and make sure it is always where we expect it to be.
Using the value in pre_copy would be fine, but TemporaryDirectory will create a
subdir under it, in which case the resulting virt-v2v will behave differently
based on whether it is running with single or two phases.

Signed-off-by: Martin Kletzander <mkletzan@redhat.com>