### PR TITLE
automation: exclude Go deps from yamllint check

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -6,9 +6,4 @@ rules:
 
 ignore: |
   .tox/
-  **/context/.travis.yml
-  **/gengo/.travis.yml
-  **/govmomi/.travis.yml
-  **/govmomi/.goreleaser.yml
-  **/imdario/mergo/testdata/license.yml
-  **/mux/.travis.yml
+  kubevirt-vmware/vendor/**


### PR DESCRIPTION
I tried this in the past but it did not work properly for some reason.
But it seems to work now so let's use that as it is easier than listing
all the (broken) files from vednored dependencies.

Signed-off-by: Tomáš Golembiovský <tgolembi@redhat.com>