### PR TITLE
spec: Do not use inline comments with %endif

### DIFF
--- a/v2v-conversion-host.spec.in
+++ b/v2v-conversion-host.spec.in
@@ -50,7 +50,8 @@ Requires: %{py3_dist libvirt-python}
 %description wrapper
 Wrapper for starting and monitoring virt-v2v.
 
-%endif # %if 0%{ansible_only} == 0
+# end of 0%{ansible_only} == 0
+%endif
 
 %prep
 %setup -c -q
@@ -62,7 +63,8 @@ export PYTHON=%{python}
 
 %if 0%{ansible_only} == 0
 %{python} setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
-%endif # %if 0%{ansible_only} == 0
+# end of 0%{ansible_only} == 0
+%endif
 
 sh build.sh install
 
@@ -82,7 +84,8 @@ sh build.sh install
 %doc docs/
 %license LICENSE
 
-%endif # %if 0%{ansible_only} == 0
+# end of 0%{ansible_only} == 0
+%endif
 
 %changelog
 * Mon Apr 27 2020 Tomáš Golembiovský <tgolembi@redhat.com> 2.4.0-1


### PR DESCRIPTION
Fixes the comment problem in #54, but not the python part of the issue.

Signed-off-by: Martin Kletzander <mkletzan@redhat.com>