### PR TITLE
Update regexp for nbdkit disk path for v1.x

### DIFF
--- a/wrapper/log_parser.py
+++ b/wrapper/log_parser.py
@@ -20,7 +20,7 @@ class OutputParser(object):
     COPY_DISK_RE = re.compile(br'.*Copying disk (\d+)/(\d+) to.*')
     DISK_PROGRESS_RE = re.compile(br'\s+\((\d+\.\d+)/100%\)')
     NBDKIT_DISK_PATH_RE = re.compile(
-        br'nbdkit: debug: Opening file (.*) \(.*\)')
+        br'nbdkit:.* debug: Opening file (.*) \(.*\)')
     OVERLAY_SOURCE_RE = re.compile(
         br' *overlay source qemu URI: json:.*"file\.path": ?"([^"]+)"')
     OVERLAY_SOURCE2_RE = re.compile(

--- a/wrapper/tests/test_output_parser.py
+++ b/wrapper/tests/test_output_parser.py
@@ -78,6 +78,10 @@ class TestOutputParser(unittest.TestCase):
                 state,
                 b'nbdkit: debug: Opening file [store1] /path1.vmdk (ha-nfcssl://[store1] path1.vmdk@1.2.3.4:902)')  # NOQA
             self.assertEqual(parser._current_path, '[store1] /path1.vmdk')
+            parser.parse_line(
+                state,
+                b'nbdkit: vddk[1]: debug: Opening file [store2] /path2.vmdk (ha-nfcssl://[store2] path2.vmdk@1.2.3.4:902)')  # NOQA
+            self.assertEqual(parser._current_path, '[store2] /path2.vmdk')
 
     def test_rhv_disk_uuid(self):
         state = wrapper.State().instance


### PR DESCRIPTION
The log format of virt-v2v has changed and it now contains the transport method, as well the disk number. This breaks the progress reporting in state file. This pull request updates the regular expression.

This is a follow up of https://github.com/ManageIQ/manageiq-v2v-conversion_host/pull/29 for v1.x version.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1810040