### PR TITLE
ovirt: change kubevirt-vmware package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ venv/
 .eggs/
 
 Pipfile.lock
+
+.idea

--- a/build.sh
+++ b/build.sh
@@ -110,7 +110,7 @@ do_build_vmware() {
         echo "Remove it and try again" >&2
         exit 1
     fi
-    IPATH="$GOPATH/src/github.com/ovirt/v2v-conversion-host/"
+    IPATH="$GOPATH/src/github.com/ManageIQ/manageiq-v2v-conversion_host/"
     mkdir -p "$IPATH"
     pushd $IPATH > /dev/null
     ln -s $(dirs -l +2)/kubevirt-vmware

--- a/kubevirt-vmware/cmd/manager/main.go
+++ b/kubevirt-vmware/cmd/manager/main.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis"
-	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/controller"
+	"github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/apis"
+	"github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/controller"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"

--- a/kubevirt-vmware/go.mod
+++ b/kubevirt-vmware/go.mod
@@ -1,4 +1,4 @@
-module github.com/ovirt/v2v-conversion-host/kubevirt-vmware
+module github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware
 
 go 1.13
 

--- a/kubevirt-vmware/pkg/apis/addtoscheme_v2v_v1alpha1.go
+++ b/kubevirt-vmware/pkg/apis/addtoscheme_v2v_v1alpha1.go
@@ -1,7 +1,7 @@
 package apis
 
 import (
-	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
+	"github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
 )
 
 func init() {

--- a/kubevirt-vmware/pkg/controller/add_v2vvmware.go
+++ b/kubevirt-vmware/pkg/controller/add_v2vvmware.go
@@ -1,10 +1,10 @@
 package controller
 
 import (
-	gc "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/controller/garbage_collector"
-	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/controller/gcovirtprovider"
-	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/controller/ovirtprovider"
-	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/controller/v2vvmware"
+	gc "github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/controller/garbage_collector"
+	"github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/controller/gcovirtprovider"
+	"github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/controller/ovirtprovider"
+	"github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/controller/v2vvmware"
 )
 
 func init() {

--- a/kubevirt-vmware/pkg/controller/garbage_collector/v2vvmware_garbagecollector.go
+++ b/kubevirt-vmware/pkg/controller/garbage_collector/v2vvmware_garbagecollector.go
@@ -7,8 +7,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	kubevirtv1alpha1 "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
-	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/controller/utils"
+	kubevirtv1alpha1 "github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
+	"github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/controller/utils"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/kubevirt-vmware/pkg/controller/gcovirtprovider/ovirtprovider_garbagecollector.go
+++ b/kubevirt-vmware/pkg/controller/gcovirtprovider/ovirtprovider_garbagecollector.go
@@ -7,8 +7,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	v2vv1alpha1 "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
-	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/controller/utils"
+	v2vv1alpha1 "github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
+	"github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/controller/utils"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/kubevirt-vmware/pkg/controller/ovirtprovider/client.go
+++ b/kubevirt-vmware/pkg/controller/ovirtprovider/client.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 
 	ovirtsdk "github.com/ovirt/go-ovirt"
-	kubevirtv1alpha1 "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
-	v2vv1alpha1 "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
+	kubevirtv1alpha1 "github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
+	v2vv1alpha1 "github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
 )
 
 // Client struct holding implementation details required to interact with oVirt engine

--- a/kubevirt-vmware/pkg/controller/ovirtprovider/ovirtprovider_controller.go
+++ b/kubevirt-vmware/pkg/controller/ovirtprovider/ovirtprovider_controller.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	v2vv1alpha1 "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
-	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/controller/utils"
+	v2vv1alpha1 "github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
+	"github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/controller/utils"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/kubevirt-vmware/pkg/controller/v2vvmware/actions.go
+++ b/kubevirt-vmware/pkg/controller/v2vvmware/actions.go
@@ -7,8 +7,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	kubevirtv1alpha1 "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
-	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/controller/utils"
+	kubevirtv1alpha1 "github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
+	"github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/controller/utils"
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/kubevirt-vmware/pkg/controller/v2vvmware/v2vvmware_controller.go
+++ b/kubevirt-vmware/pkg/controller/v2vvmware/v2vvmware_controller.go
@@ -3,9 +3,9 @@ package v2vvmware
 import (
 	"context"
 	"fmt"
-	"github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/controller/utils"
+	"github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/controller/utils"
 
-	kubevirtv1alpha1 "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
+	kubevirtv1alpha1 "github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/kubevirt-vmware/pkg/controller/v2vvmware/vmware.go
+++ b/kubevirt-vmware/pkg/controller/v2vvmware/vmware.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	kubevirtv1alpha1 "github.com/ovirt/v2v-conversion-host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
+	kubevirtv1alpha1 "github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
 )
 
 /*

--- a/wrapper/tests/test_output_parser.py
+++ b/wrapper/tests/test_output_parser.py
@@ -83,8 +83,8 @@ class TestOutputParser(unittest.TestCase):
                     br"openstack '--os-username=admin' '--os-identity-api-version=3' '--os-user-domain-name=Default' '--os-auth-url=http://10.19.2.25:5000//v3' '--os-volume-api-version=3' '--os-project-domain-name=Default' '--os-project-name=admin' '--os-password=100Root-' 'volume' 'show' '-f' 'json' '77c51545-f2a4-4bbf-8f04-169a15c23354'",  # NOQA
                     br"openstack '--os-username=admin' '--os-identity-api-version=3' '--os-user-domain-name=Default' '--os-auth-url=http://10.19.2.25:5000//v3' '--os-volume-api-version=3' '--os-project-domain-name=Default' '--os-project-name=admin' '--os-password=100Root-' 'volume' 'show' '-f' 'json' 'd85b7a6f-bffa-4b77-93df-912afd6e7014'",  # NOQA
                     ]
-            for l in lines:
-                parser.parse_line(l)
+            for line in lines:
+                parser.parse_line(line)
             self.assertIn(1, STATE.internal['disk_ids'])
             self.assertIn(2, STATE.internal['disk_ids'])
             self.assertEqual(


### PR DESCRIPTION
Changed the kubevirt-vmware package name to reflect current location of the repository.

`wrapper/tests/test_output_parser.py` changes are part of #60; included here to satisfy Travis build.

Signed-off-by: Jakub Dzon <jdzon@redhat.com>