### PR TITLE
ovirt: expose vm status information

### DIFF
--- a/kubevirt-vmware/pkg/controller/ovirtprovider/client.go
+++ b/kubevirt-vmware/pkg/controller/ovirtprovider/client.go
@@ -122,6 +122,7 @@ type vm struct {
 	Memory      int64           `json:"memory"`
 	Name        string          `json:"name"`
 	Nics        []nic           `json:"nics"`
+	Status      string          `json:"status"`
 	OS          operatingSystem `json:"os"`
 	VMType      string          `json:"vmtype"`
 }
@@ -165,6 +166,9 @@ func (c *Client) getRaw(sourceVM *ovirtsdk.Vm) (string, error) {
 	}
 	if desc, ok := sourceVM.Description(); ok {
 		vm.Description = desc
+	}
+	if status, ok := sourceVM.Status(); ok {
+		vm.Status = string(status)
 	}
 	if vmID, ok := sourceVM.Id(); ok {
 		vm.ID = vmID


### PR DESCRIPTION
We would like to warn user about running vm before stopping it.

Fixes: https://github.com/ManageIQ/manageiq-v2v-conversion_host/issues/65

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>