### PR TITLE
Fix unprofessional log message

### DIFF
--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -140,7 +140,7 @@ def prepare_command(data, v2v_caps, agent_sock=None):
     v2v_env['LANG'] = 'C'
     if 'backend' in data:
         if data['backend'] == 'direct':
-            logging.debug('Using direct backend. Hack, hack...')
+            logging.debug('Using direct backend.')
         v2v_env['LIBGUESTFS_BACKEND'] = data['backend']
     if 'virtio_win' in data:
         v2v_env['VIRTIO_WIN'] = data['virtio_win']


### PR DESCRIPTION
It was reported that one of the log messages doesn't look "professional". This pull request removes the "Hack, hack..." part in the message about the "direct" backend.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1821209