### PR TITLE
ansible: don't check if nbdkit plugin works properly (RHBZ#1847898)

### DIFF
--- a/ansible/oVirt.v2v-conversion-host/tasks/check-transport-vddk-facts.yml
+++ b/ansible/oVirt.v2v-conversion-host/tasks/check-transport-vddk-facts.yml
@@ -11,16 +11,7 @@
   ignore_errors: "yes"
   register: stat_nbdkit_plugin
 
-- name: Check if VDDK nbdkit plugin works
-  command: nbdkit --dump-plugin vddk
-  environment:
-    LD_LIBRARY_PATH: "{{ v2v_vddk_install_dir }}/vmware-vix-disklib-distrib/lib64"
-  ignore_errors: "yes"
-  register: command_nbdkit_plugin
-  changed_when: false
-
 - name: Set VDDK and nbdkit facts
   set_fact:
     v2v_vddk_library_installed: "{{ stat_vddk_library.stat.exists }}"
     v2v_nbdkit_plugin_installed: "{{ stat_nbdkit_plugin.stat.exists }}"
-    v2v_nbdkit_plugin_working: "{{ command_nbdkit_plugin.rc == 0 }}"

--- a/ansible/oVirt.v2v-conversion-host/tasks/check-transport-vddk.yml
+++ b/ansible/oVirt.v2v-conversion-host/tasks/check-transport-vddk.yml
@@ -10,8 +10,3 @@
   assert:
     that: "{{ v2v_nbdkit_plugin_installed }}"
     msg: "VDDK nbdkit plugin is not installed"
-
-- name: Assert that VDDK nbdkit plugin test succeeded
-  assert:
-    that: "{{ v2v_nbdkit_plugin_working }}"
-    msg: "VDDK nbdkit plugin failed validation"


### PR DESCRIPTION
The check is currently failing on latest EL8. After discussion it turned
out that calling the nbdkit properly so that it universaly works is not
so trivial anymore. It seems best to remove the deployment check and let
virt-v2v do it properly before conversion.

Signed-off-by: Tomáš Golembiovský <tgolembi@redhat.com>