### PR TITLE
build: remove Kubevirt content from dist package

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -46,7 +46,8 @@ do_dist() {
    -e "s|@PACKAGE_NAME@|$PACKAGE_NAME|g" \
    < "$PACKAGE_NAME.spec.in" > "$PACKAGE_NAME.spec"
 
-  git ls-files | tar --files-from /proc/self/fd/0 -czf "$TARBALL" "$PACKAGE_NAME.spec"
+  git ls-files | grep -v '^kubevirt-conversion\|^kubevirt-vmware' | \
+      tar --files-from /proc/self/fd/0 -czf "$TARBALL" "$PACKAGE_NAME.spec"
   echo "tar archive '$TARBALL' created."
 }
 


### PR DESCRIPTION
Do not include the Kubevirt content as it makes the package
unnecessarily large. The releases from master branch are the proper
source of the source files if anyone wishes to use the dist package (and
not to use git repo). As for the kubevirt v2v container the source is in
MangeIQ/manageiq-v2v-conversion_host-build repository.

Signed-off-by: Tomáš Golembiovský <tgolembi@redhat.com>