### PR TITLE
remove check for oVirt version

### DIFF
--- a/ansible/oVirt.v2v-conversion-host/tasks/install-validate-rhevm.yml
+++ b/ansible/oVirt.v2v-conversion-host/tasks/install-validate-rhevm.yml
@@ -1,9 +1,4 @@
 ---
-- name: Validate RHV host -- RHV version requirement
-  command: /usr/bin/virt-v2v-wrapper.py --check-rhv-version
-  when: v2v_checks_override is not defined or not v2v_checks_override
-  changed_when: false
-
 - name: Validate RHV host -- RHV Guest Tools
   command: /usr/bin/virt-v2v-wrapper.py --check-rhv-guest-tools
   when: v2v_checks_override is not defined or not v2v_checks_override

--- a/wrapper/checks.py
+++ b/wrapper/checks.py
@@ -1,10 +1,6 @@
 from .hosts import BaseHost
 
 
-VDSM_MIN_RHV = '4.2.4'  # This has to match VDSM_MIN_VERSION!
-VDSM_MIN_VERSION = '4.20.31'  # RC4, final
-
-
 def check_rhv_guest_tools():
     """
     Make sure there is ISO domain with at least one ISO with windows drivers.
@@ -16,27 +12,6 @@ def check_rhv_guest_tools():
     return ('virtio_win' in data)
 
 
-def check_rhv_version():
-    import rpmUtils.transaction
-    import rpmUtils.miscutils
-
-    ts = rpmUtils.transaction.initReadOnlyTransaction()
-    match = ts.dbMatch('name', 'vdsm')
-    if len(match) >= 1:
-        vdsm = match.next()
-        res = rpmUtils.miscutils.compareEVR(
-            (vdsm['epoch'], vdsm['version'], None),  # Ignore release number
-            rpmUtils.miscutils.stringToVersion(VDSM_MIN_VERSION))
-        if res >= 0:
-            return True
-        print('Version of VDSM on the host: {}{}'.format(
-                '' if vdsm['epoch'] is None else '%s:' % vdsm['epoch'],
-                vdsm['version']))
-    print('Minimal required oVirt/RHV version is %s' % VDSM_MIN_RHV)
-    return False
-
-
 CHECKS = {
     'rhv-guest-tools': check_rhv_guest_tools,
-    'rhv-version': check_rhv_version,
 }


### PR DESCRIPTION
This is broken on EL8 host because the yum python module is not
installed by default. But oVirt 4.2 is long obsolete and we don't
really support anything but the latest version anyway.

Signed-off-by: Tomáš Golembiovský <tgolembi@redhat.com>