### PR TITLE
wrapper: tools patterns have to be str not bytes

### DIFF
--- a/wrapper/hosts.py
+++ b/wrapper/hosts.py
@@ -603,14 +603,14 @@ class VDSMHost(BaseHost):
     TYPE = BaseHost.TYPE_VDSM
 
     TOOLS_PATTERNS = [
-        (7, br'RHV-toolsSetup_([0-9._]+)\.iso'),
-        (6, br'rhv-tools-setup\.iso'),
-        (5, br'RHEV-toolsSetup_([0-9._]+)\.iso'),
-        (4, br'rhev-tools-setup\.iso'),
-        (3, br'oVirt-toolsSetup_([a-z0-9._-]+)\.iso'),
-        (2, br'ovirt-tools-setup\.iso'),
-        (1, br'virtio-win-([0-9.]+).iso'),
-        (0, br'virtio-win\.iso'),
+        (7, r'RHV-toolsSetup_([0-9._]+)\.iso'),
+        (6, r'rhv-tools-setup\.iso'),
+        (5, r'RHEV-toolsSetup_([0-9._]+)\.iso'),
+        (4, r'rhev-tools-setup\.iso'),
+        (3, r'oVirt-toolsSetup_([a-z0-9._-]+)\.iso'),
+        (2, r'ovirt-tools-setup\.iso'),
+        (1, r'virtio-win-([0-9.]+).iso'),
+        (0, r'virtio-win\.iso'),
         ]
     VDSM_LOG_DIR = '/var/log/vdsm/import'
     VDSM_MOUNTS = '/rhev/data-center/mnt'
@@ -891,7 +891,7 @@ class VDSMHost(BaseHost):
                 if not m:
                     continue
                 if len(m.groups()) == 0:
-                    version = b''
+                    version = ''
                 else:
                     version = m.group(1)
                 logging.debug('Matched ISO %r (priority %d)', fname, priority)

--- a/wrapper/tests/test_rhv.py
+++ b/wrapper/tests/test_rhv.py
@@ -16,58 +16,58 @@ class TestRHV(unittest.TestCase):
     def test_tools_iso_ordering(self):
         host = hosts.VDSMHost()
         self.assertEqual(
-                b'virtio-win-123.iso',
-                host._filter_iso_names(b'/', [
-                    b'a.iso',
-                    b'virtio-win-123.iso',
-                    b'b.iso',
+                'virtio-win-123.iso',
+                host._filter_iso_names('/', [
+                    'a.iso',
+                    'virtio-win-123.iso',
+                    'b.iso',
                     ]))
         # Priority
         self.assertEqual(
-                b'RHEV-toolsSetup_123.iso',
-                host._filter_iso_names(b'/', [
-                    b'RHEV-toolsSetup_123.iso',
-                    b'virtio-win-123.iso',
+                'RHEV-toolsSetup_123.iso',
+                host._filter_iso_names('/', [
+                    'RHEV-toolsSetup_123.iso',
+                    'virtio-win-123.iso',
                     ]))
         self.assertEqual(
-                b'RHEV-toolsSetup_123.iso',
-                host._filter_iso_names(b'/', [
-                    b'virtio-win-123.iso',
-                    b'RHEV-toolsSetup_123.iso',
+                'RHEV-toolsSetup_123.iso',
+                host._filter_iso_names('/', [
+                    'virtio-win-123.iso',
+                    'RHEV-toolsSetup_123.iso',
                     ]))
         self.assertEqual(
-                b'RHEV-toolsSetup_234.iso',
-                host._filter_iso_names(b'/', [
-                    b'RHEV-toolsSetup_123.iso',
-                    b'virtio-win-123.iso',
-                    b'RHEV-toolsSetup_234.iso',
+                'RHEV-toolsSetup_234.iso',
+                host._filter_iso_names('/', [
+                    'RHEV-toolsSetup_123.iso',
+                    'virtio-win-123.iso',
+                    'RHEV-toolsSetup_234.iso',
                     ]))
         self.assertEqual(
-                b'RHEV-toolsSetup_234.iso',
-                host._filter_iso_names(b'/', [
-                    b'RHEV-toolsSetup_234.iso',
-                    b'virtio-win-123.iso',
-                    b'RHEV-toolsSetup_123.iso',
+                'RHEV-toolsSetup_234.iso',
+                host._filter_iso_names('/', [
+                    'RHEV-toolsSetup_234.iso',
+                    'virtio-win-123.iso',
+                    'RHEV-toolsSetup_123.iso',
                     ]))
         self.assertEqual(
-                b'rhv-tools-setup.iso',
-                host._filter_iso_names(b'/', [
-                    b'rhv-tools-setup.iso',
-                    b'virtio-win-123.iso',
+                'rhv-tools-setup.iso',
+                host._filter_iso_names('/', [
+                    'rhv-tools-setup.iso',
+                    'virtio-win-123.iso',
                     ]))
         # Version
         self.assertEqual(
-                b'RHEV-toolsSetup_4.0_3.iso',
-                host._filter_iso_names(b'/', [
-                    b'RHEV-toolsSetup_4.0_3.iso',
-                    b'RHEV-toolsSetup_4.0_2.iso',
+                'RHEV-toolsSetup_4.0_3.iso',
+                host._filter_iso_names('/', [
+                    'RHEV-toolsSetup_4.0_3.iso',
+                    'RHEV-toolsSetup_4.0_2.iso',
                     ]))
 
         self.assertEqual(
-                b'RHEV-toolsSetup_4.1_3.iso',
-                host._filter_iso_names(b'/', [
-                    b'RHEV-toolsSetup_4.0_3.iso',
-                    b'RHEV-toolsSetup_4.1_3.iso',
+                'RHEV-toolsSetup_4.1_3.iso',
+                host._filter_iso_names('/', [
+                    'RHEV-toolsSetup_4.0_3.iso',
+                    'RHEV-toolsSetup_4.1_3.iso',
                     ]))
 
     VDDK_RHV = {


### PR DESCRIPTION
`os.walk()` returns names as `str` which means `os.listdir()` will also
return names as `str`. That all means our patterns have to be `str` too.

Signed-off-by: Tomáš Golembiovský <tgolembi@redhat.com>