### PR TITLE
Handle missing vnicProfiles

### DIFF
--- a/kubevirt-vmware/pkg/controller/ovirtprovider/client.go
+++ b/kubevirt-vmware/pkg/controller/ovirtprovider/client.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	ovirtsdk "github.com/ovirt/go-ovirt"
 	kubevirtv1alpha1 "github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
 	v2vv1alpha1 "github.com/ManageIQ/manageiq-v2v-conversion_host/kubevirt-vmware/pkg/apis/v2v/v1alpha1"
+	ovirtsdk "github.com/ovirt/go-ovirt"
 )
 
 // Client struct holding implementation details required to interact with oVirt engine
@@ -279,25 +279,27 @@ func (c *Client) getRaw(sourceVM *ovirtsdk.Vm) (string, error) {
 		if nicInterface, ok := vmNic.Interface(); ok {
 			nic.Interface = string(nicInterface)
 		}
-		profileLink, _ := vmNic.VnicProfile()
-		profile, err := c.conn.FollowLink(profileLink)
-		if err != nil {
-			return "", err
-		}
-		vnic := profile.(*ovirtsdk.VnicProfile)
-		if vnicID, ok := vnic.Id(); ok {
-			nic.VnicID = vnicID
-		}
-		networkLink, _ := vnic.Network()
-		network, err := c.conn.FollowLink(networkLink)
-		if err != nil {
-			return "", err
-		}
-		net := network.(*ovirtsdk.Network)
-		if name, ok := net.Name(); ok {
-			nic.NetName = name
-			if vnicName, ok := vnic.Name(); ok {
-				nic.VnicNetName = name + "/" + vnicName
+		if profileLink, ok := vmNic.VnicProfile(); ok {
+			profile, err := c.conn.FollowLink(profileLink)
+			if err != nil {
+				return "", err
+			}
+			vnic := profile.(*ovirtsdk.VnicProfile)
+			if vnicID, ok := vnic.Id(); ok {
+				nic.VnicID = vnicID
+			}
+			if networkLink, ok := vnic.Network(); ok {
+				network, err := c.conn.FollowLink(networkLink)
+				if err != nil {
+					return "", err
+				}
+				net := network.(*ovirtsdk.Network)
+				if name, ok := net.Name(); ok {
+					nic.NetName = name
+					if vnicName, ok := vnic.Name(); ok {
+						nic.VnicNetName = name + "/" + vnicName
+					}
+				}
 			}
 		}
 		vm.Nics = append(vm.Nics, *nic)


### PR DESCRIPTION
When we try to import a vm without vnicProfiles it causes provider pod to crash. This PR fixes the issue.

Bug-Url: https://bugzilla.redhat.com/1851886
Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>