### PR TITLE
Reduce number of connect retries

### DIFF
--- a/kubevirt-vmware/pkg/controller/ovirtprovider/ovirtprovider_controller.go
+++ b/kubevirt-vmware/pkg/controller/ovirtprovider/ovirtprovider_controller.go
@@ -26,8 +26,9 @@ import (
 const ovirtSecretKey = "ovirt"
 
 var (
-	log        = logf.Log.WithName("controller_ovirtprovider")
-	timeToWait = time.Duration(5 * time.Minute)
+	log           = logf.Log.WithName("controller_ovirtprovider")
+	timeToWait    = time.Duration(1 * time.Minute)
+	timeToRequeue = time.Duration(10 * time.Second)
 )
 
 // Add creates a new OVirtProvider Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -155,7 +156,7 @@ func (r *ReconcileOVirtProvider) checkTime(instance *v2vv1alpha1.OVirtProvider, 
 		return reconcile.Result{}, nil
 	}
 	// wait for user to update the secret
-	return reconcile.Result{}, err
+	return reconcile.Result{RequeueAfter: timeToRequeue}, err
 }
 
 func (r *ReconcileOVirtProvider) fetchSecret(provider *v2vv1alpha1.OVirtProvider) (*corev1.Secret, error) {


### PR DESCRIPTION
When we fail to verify credentials we used to requeue verification without any timeout. This cycle was done for 5mins. With this PR
we reduce timeout to 1min with 10secs requeue delay.

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>