### PR TITLE
wrapper: final progress update after virt-v2v finished (RHBZ# 1878460)

### DIFF
--- a/wrapper/virt_v2v_wrapper.py
+++ b/wrapper/virt_v2v_wrapper.py
@@ -271,6 +271,7 @@ def wrapper(host, data, v2v_caps, agent_sock=None):
                 'virt-v2v terminated with return code %d',
                 runner.return_code)
             state = parser.parse(state)
+            host.update_progress()
     except Exception:
         state['failed'] = True
         error('Error while monitoring virt-v2v', exception=True)


### PR DESCRIPTION
We did not update the progress after virt-v2v finished. This could
result in situations where the progress remained on number that was less
than 100% in Kubevirt. Let's call update on progress one last time to
make sure it reaches 100%.

Signed-off-by: Tomáš Golembiovský <tgolembi@redhat.com>