### PR TITLE
Added symlink to go.mod file in root

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+vm-import-provider/go.mod


### PR DESCRIPTION
Red Hat is building an image of this repository in it's internal build system that requires a go.mod
file in the root so that it can get the dependencies, this PR creates symlink file in the root that references the go.mod file.

Signed-off-by: Nikolas Komonen <nkomonen@redhat.com>