### PR TITLE
Install nbdkit-vddk-plugin on EL 8

### DIFF
--- a/ansible/oVirt.v2v-conversion-host/tasks/install-transport-vddk.yml
+++ b/ansible/oVirt.v2v-conversion-host/tasks/install-transport-vddk.yml
@@ -32,7 +32,14 @@
       not v2v_nbdkit_plugin_installed or
       not v2v_nbdkit_plugin_working
 
-- name: Make sure VDDK plugin is installed
+- name: Make sure VDDK plugin is installed (EL7)
   yum:
     state: "{{ v2v_yum_check }}"
     name: nbdkit-plugin-vddk
+  when: ansible_distribution_major_version == "7"
+
+- name: Make sure VDDK plugin is installed (EL8)
+  yum:
+    state: "{{ v2v_yum_check }}"
+    name: nbdkit-vddk-plugin
+  when: ansible_distribution_major_version == "8"


### PR DESCRIPTION
When running the playbook against oVirt 4.4, the `nbdkit-plugin-vddk` package doesn't exist. It has been renamed to `nbdkit-vddk-plugin` on EL8. This pull request adds conditions to support both EL7 and EL8.