### PR TITLE
ansible: don't explicitly check for VDDK plugin

### DIFF
--- a/ansible/oVirt.v2v-conversion-host/tasks/install-transport-vddk.yml
+++ b/ansible/oVirt.v2v-conversion-host/tasks/install-transport-vddk.yml
@@ -36,9 +36,3 @@
     state: "{{ v2v_yum_check }}"
     name: nbdkit-plugin-vddk
   when: ansible_distribution_major_version == "7"
-
-- name: Make sure VDDK plugin is installed (EL8)
-  yum:
-    state: "{{ v2v_yum_check }}"
-    name: nbdkit-vddk-plugin
-  when: ansible_distribution_major_version == "8"


### PR DESCRIPTION
In Advanced Virtualization on EL8 we don't have to explicitly
check/install VDDK plugin for nbdkit. virt-v2v in Advanced
Virtualization explicitly requires nbdkit which explicitly requires the
VDDK plugin.

Note: This is true only for package from Advanced Virtualization, but we
don't expect anyone using the packages from base EL!

Signed-off-by: Tomáš Golembiovský <tgolembi@redhat.com>