### PR TITLE
Fix /etc/cron.daily/virt-v2v-logs removal

### DIFF
--- a/ansible/oVirt.v2v-conversion-host/tasks/uninstall-provider-openstack.yml
+++ b/ansible/oVirt.v2v-conversion-host/tasks/uninstall-provider-openstack.yml
@@ -2,3 +2,4 @@
 - name: Delete cron job for log cleanup
   file:
     path: /etc/cron.daily/virt-v2v-logs
+    state: absent


### PR DESCRIPTION
If the installation role was incomplete and didn't create the /etc/cron.daily/virt-v2v-logs file, then the role would fail when trying to uninstall it as the `state` is not specified.