### PR TITLE
Allow OpenStack conversion host based on EL8

### DIFF
--- a/ansible/oVirt.v2v-conversion-host/tasks/install-provider-openstack.yml
+++ b/ansible/oVirt.v2v-conversion-host/tasks/install-provider-openstack.yml
@@ -1,11 +1,21 @@
 ---
-- name: Install packages for OpenStack appliance
+- name: Install packages for OpenStack appliance (EL7)
   yum:
     name:
       - python2-openstackclient
       - virtio-win
       - python-six
     state: "{{ v2v_yum_check }}"
+  when: ansible_distribution_major_version == "7"
+
+- name: Install packages for OpenStack appliance (EL8)
+  yum:
+    name:
+      - python3-openstackclient
+      - python3-six
+      - virtio-win
+    state: "{{ v2v_yum_check }}"
+  when: ansible_distribution_major_version == "8"
 
 - name: Create cron job for log cleanup
   copy:

--- a/wrapper/hosts.py
+++ b/wrapper/hosts.py
@@ -378,7 +378,7 @@ class OSPHost(BaseHost):
                     return False
                 volume_state = volume_state.rstrip()
                 logging.info('Current volume state: %s.', volume_state)
-                if volume_state == 'available':
+                if volume_state in ['available', b'available']:
                     logging.info(
                         'Volume detached in %s second(s), trasferring.',
                         int(time.time() - start_at))


### PR DESCRIPTION
While our current assumption is that the conversion host is based on EL7 for OpenStack, it may happen that a user wants to use EL8 to benefit from more recent versions of virt-v2v and nbdkit, e.g. to use VDDK 7.0. This pull request adds support for the new names of the packages in EL 8. It has been tested in a real environment.